### PR TITLE
Replaced default z value in scalar gradients

### DIFF
--- a/toy_model.py
+++ b/toy_model.py
@@ -103,15 +103,15 @@ dz[-1] = dz[-2]
 
 # define various useful differential functions:
 # gradient of scalar field a in the local x direction at point i,j
-def scalar_gradient_x(a,i,j,k=999):
-	if k == 999:
+def scalar_gradient_x(a,i,j,k=-1):
+	if k == -1:
 		return (a[i,(j+1)%nlon]-a[i,(j-1)%nlon])/dx[i]
 	else:
 		return (a[i,(j+1)%nlon,k]-a[i,(j-1)%nlon,k])/dx[i]
 
 # gradient of scalar field a in the local y direction at point i,j
-def scalar_gradient_y(a,i,j,k=999):
-	if k == 999:
+def scalar_gradient_y(a,i,j,k=-1):
+	if k == -1:
 		if i == 0:
 			return 2*(a[i+1,j]-a[i,j])/dy
 		elif i == nlat-1:


### PR DESCRIPTION
This pull request attempts to replace the default z value in x and y scalar gradients from `999` to `-1`. The reasoning behind this change is that a model with (up to) 999 atmosphere layers could exist even if the computations would take forever, while needing the scalar gradient of a point in the -1st layer of atmosphere is impossible. The only problem with this alternative is that using negative indices for the height "coordinate" would be forbidden and it should be taken into consideration when coding any new functionalities.

Something to note is that `None` would be the preferred option in most cases but, given that it will eventually be compiled using Cython, using `None` could potentially give more trouble down the line as it cannot be translated easily into C.

There might be better options than the one presented here. In [this Stack Overflow answer](https://stackoverflow.com/a/54118721), creating a Python object that could hold either an integer value or a `None` is proposed, but it could make the code slower defeating the purpose of using Cython.