### PR TITLE
Added tkinter as a requirement

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -69,6 +69,8 @@ The following programs and libraries are required to build CLAuDE:
 
 If you're using apt as your package manager, these correspond to the packages `git` `python3` `python3-setuptools` `cython3` `python3-numpy` `python3-matplotlib`.
 
+Depending upon your system you may also need to install `tkinter` to view the graphics, which corresponds to the package `python3-tk`.
+
 ### 1. Clone the repository.
 Using the git command line, and cloning via https, this command will do it:
 ```


### PR DESCRIPTION
If you don't have tkinter on your system, and my version of xubuntu doesn't doesn't by default, then running the toy-model script just outputs the text and doesn't generate the graphics along with.

Matplotlib will also print the following warning "UserWarning: Matplotlib is currently using agg, which is a non-GUI backend, so cannot show the figure.” which was my hint that I was supposed to be seeing something.