### PR TITLE
Increase speed 5x through np matrix operations

### DIFF
--- a/claude_low_level_library.pyx
+++ b/claude_low_level_library.pyx
@@ -104,12 +104,7 @@ cpdef t_to_theta(np.ndarray temperature_atmos, np.ndarray pressure_levels):
 	return output
 
 cpdef theta_to_t(np.ndarray theta, np.ndarray pressure_levels):
-	cdef np.ndarray output = np.zeros_like(theta)
-	cdef np.int_t k
-	cdef DTYPE_f inv_p0
-
-	inv_p0 = 1/pressure_levels[0]
-	for k in range(len(pressure_levels)):
-		output[:,:,k] = theta[:,:,k]*(pressure_levels[k]*inv_p0)**(0.286)
+	cdef DTYPE_f inv_p0 = 1/pressure_levels[0]
+	cdef np.ndarray output = theta*(pressure_levels*inv_p0)**(0.286)
 
 	return output

--- a/claude_top_level_library.pyx
+++ b/claude_top_level_library.pyx
@@ -49,51 +49,45 @@ cpdef divergence_with_scalar(np.ndarray a,np.ndarray u,np.ndarray v,np.ndarray w
 
 cpdef radiation_calculation(np.ndarray temperature_world, np.ndarray potential_temperature, np.ndarray pressure_levels, np.ndarray heat_capacity_earth, np.ndarray albedo, DTYPE_f insolation, np.ndarray lat, np.ndarray lon, np.int_t t, np.int_t dt, DTYPE_f day, DTYPE_f year, DTYPE_f axial_tilt):
 	# calculate change in temperature of ground and atmosphere due to radiative imbalance
-	cdef np.int_t nlat,nlon,nlevels,i,j,k
+	cdef np.int_t nlat,nlon,nlevels,k
 	cdef DTYPE_f fl = 0.1
-	cdef np.ndarray upward_radiation,downward_radiation,optical_depth,Q,temperature_atmos
-	cdef DTYPE_f sun_lat, inv_day
+	cdef DTYPE_f inv_day = 1/(24*60*60)
 
-	inv_day = 1/(24*60*60)
+	nlat = lat.shape[0]	
+	nlon = lon.shape[0]
+	nlevels = pressure_levels.shape[0]
 
-	temperature_atmos = low_level.theta_to_t(potential_temperature,pressure_levels)
-	nlat = temperature_atmos.shape[0]	
-	nlon = temperature_atmos.shape[1]
-	nlevels = temperature_atmos.shape[2]
+	cdef np.ndarray temperature_atmos = low_level.theta_to_t(potential_temperature,pressure_levels)
+	cdef np.ndarray sun_lat = low_level.surface_optical_depth_array(lat)
+	cdef np.ndarray optical_depth = np.outer(sun_lat, (fl*(pressure_levels/pressure_levels[0]) + (1-fl)*(pressure_levels/pressure_levels[0])**4))
 
-	upward_radiation = np.zeros(nlevels)
-	downward_radiation = np.zeros(nlevels)
-	Q = np.zeros(nlevels)
+	# calculate upward longwave flux, bc is thermal radiation at surface
+	cpdef np.ndarray upward_radiation = np.zeros((nlat,nlon,nlevels))
+	upward_radiation[:,:,0] = low_level.thermal_radiation_matrix(temperature_world)
+	for k in np.arange(1,nlevels):
+		upward_radiation[:,:,k] = (upward_radiation[:,:,k-1] - (optical_depth[:,None,k]-optical_depth[:,None,k-1])*(low_level.thermal_radiation_matrix(temperature_atmos[:,:,k])))/(1 + optical_depth[:,None,k-1] - optical_depth[:,None,k])
 
-	for i in range(nlat):
-		
-		sun_lat = low_level.surface_optical_depth(lat[i])
-		optical_depth = sun_lat*(fl*(pressure_levels/pressure_levels[0]) + (1-fl)*(pressure_levels/pressure_levels[0])**4)
-		
-		for j in range(nlon):
-			
-			# calculate upward longwave flux, bc is thermal radiation at surface
-			upward_radiation[0] = low_level.thermal_radiation(temperature_world[i,j])
-			for k in np.arange(1,nlevels):
-				upward_radiation[k] = (upward_radiation[k-1] - (optical_depth[k]-optical_depth[k-1])*(low_level.thermal_radiation(temperature_atmos[i,j,k])))/(1 + optical_depth[k-1] - optical_depth[k])
-
-			# calculate downward longwave flux, bc is zero at TOA (in model)
-			downward_radiation[-1] = 0
-			for k in np.arange(0,nlevels-1)[::-1]:
-				downward_radiation[k] = (downward_radiation[k+1] - low_level.thermal_radiation(temperature_atmos[i,j,k])*(optical_depth[k+1]-optical_depth[k]))/(1 + optical_depth[k] - optical_depth[k+1])
-			
-			# gradient of difference provides heating at each level
-			for k in np.arange(nlevels):
-				Q[k] = -287*temperature_atmos[i,j,k]*low_level.scalar_gradient_z_1D(upward_radiation-downward_radiation,pressure_levels,k)/(1000*pressure_levels[k])
-				# approximate SW heating of ozone
-				if pressure_levels[k] < 400*100:
-					Q[k] += low_level.solar(75,lat[i],lon[j],t,day, year, axial_tilt)*inv_day*(100/pressure_levels[k])
-
-			temperature_atmos[i,j,:] += Q*dt
-
-			# update surface temperature with shortwave radiation flux
-			temperature_world[i,j] += dt*((1-albedo[i,j])*(low_level.solar(insolation,lat[i],lon[j],t, day, year, axial_tilt) + downward_radiation[0]) - upward_radiation[0])/heat_capacity_earth[i,j] 
+	# calculate downward longwave flux, bc is zero at TOA (in model)
+	cpdef np.ndarray downward_radiation = np.zeros((nlat,nlon,nlevels))
+	downward_radiation[:,:,-1] = 0
+	for k in np.arange(0,nlevels-1)[::-1]:
+		downward_radiation[:,:,k] = (downward_radiation[:,:,k+1] - low_level.thermal_radiation_matrix(temperature_atmos[:,:,k])*(optical_depth[:,None,k+1]-optical_depth[:,None,k]))/(1 + optical_depth[:,None,k] - optical_depth[:,None,k+1])
 	
+	# gradient of difference provides heating at each level
+	cpdef np.ndarray Q = np.zeros((nlat,nlon,nlevels))
+	cpdef np.ndarray z_gradient = low_level.scalar_gradient_z_matrix(upward_radiation - downward_radiation, pressure_levels)
+	cpdef np.ndarray solar_matrix = low_level.solar_matrix(75,lat,lon,t,day, year, axial_tilt)
+	for k in np.arange(nlevels):
+		Q[:,:,k] = -287*temperature_atmos[:,:,k]*z_gradient[:,:,k]/(1000*pressure_levels[None,None,k])
+		# approximate SW heating of ozone
+		if pressure_levels[k] < 400*100:
+			Q[:,:,k] += solar_matrix*inv_day*(100/pressure_levels[k])
+
+	temperature_atmos += Q*dt
+
+	# update surface temperature with shortwave radiation flux
+	temperature_world += dt*((1-albedo)*(low_level.solar_matrix(insolation,lat,lon,t, day, year, axial_tilt) + downward_radiation[:,:,0]) - upward_radiation[:,:,0])/heat_capacity_earth 
+
 	return temperature_world, low_level.t_to_theta(temperature_atmos,pressure_levels)
 
 cpdef velocity_calculation(np.ndarray u,np.ndarray v,np.ndarray w,np.ndarray pressure_levels,np.ndarray geopotential,np.ndarray potential_temperature,np.ndarray coriolis,DTYPE_f gravity,np.ndarray dx,DTYPE_f dy,DTYPE_f dt):

--- a/toy_model.py
+++ b/toy_model.py
@@ -435,19 +435,17 @@ while True:
 
 		before_velocity = time.time()
 		u,v = top_level.velocity_calculation(u,v,w,pressure_levels,geopotential,potential_temperature,coriolis,gravity,dx,dy,dt)
-		print('1:', time.time() - before_velocity)
 		u = top_level.smoothing_3D(u,smoothing_parameter_u)
 		v = top_level.smoothing_3D(v,smoothing_parameter_v)
-		print('2:', time.time() - before_velocity)
+		print('velo 1:', time.time() - before_velocity)
 		w = top_level.w_calculation(u,v,w,pressure_levels,geopotential,potential_temperature,coriolis,gravity,dx,dy,dt)
 		w = top_level.smoothing_3D(w,smoothing_parameter_w,0.25)
-		print('3:', time.time() - before_velocity)
+		print('velo 2:', time.time() - before_velocity)
 		u[:,:,-1] *= 0.1
 		v[:,:,-1] *= 0.1
 
 		for k in range(nlevels):
 			w[:,:,k] *= pressure_levels[k]/pressure_levels[0]
-		print('4:', time.time() - before_velocity)
 		w[:,:,0] = -w[:,:,1]
 		# w[:,:,2] *= 0.1
 		# w[:,:,3] *= 0.5

--- a/toy_model.py
+++ b/toy_model.py
@@ -97,13 +97,10 @@ for i in range(len(sigma)):
 
 ###########################
 
-albedo = np.zeros_like(temperature_world) + 0.2
 heat_capacity_earth = np.zeros_like(temperature_world) + 1E6
 
 albedo_variance = 0.001
-for i in range(nlat):
-	for j in range(nlon):
-		albedo[i,j] += np.random.uniform(-albedo_variance,albedo_variance)
+albedo = np.random.uniform(-albedo_variance,albedo_variance, (nlat, nlon)) + 0.2
 
 specific_gas = 287
 thermal_diffusivity_roc = 1.5E-6
@@ -138,14 +135,8 @@ grid_xx_S,grid_yy_S = np.meshgrid(grid_x_values_S,grid_y_values_S)
 
 grid_side_length = len(grid_x_values_S)
 
-grid_lat_coords_S = []
-grid_lon_coords_S = []
-for i in range(grid_xx_S.shape[0]):
-	for j in range(grid_xx_S.shape[1]):
-		lat_point = -np.arccos((grid_xx_S[i,j]**2 + grid_yy_S[i,j]**2)**0.5/planet_radius)*180/np.pi
-		lon_point = 180 - np.arctan2(grid_yy_S[i,j],grid_xx_S[i,j])*180/np.pi
-		grid_lat_coords_S.append(lat_point)
-		grid_lon_coords_S.append(lon_point)
+grid_lat_coords_S = (-np.arccos((grid_xx_S**2 + grid_yy_S**2)**0.5/planet_radius)*180/np.pi).flatten()
+grid_lon_coords_S = (180 - np.arctan2(grid_yy_S,grid_xx_S)*180/np.pi).flatten()
 
 polar_x_coords_S = []
 polar_y_coords_S = []
@@ -162,14 +153,8 @@ grid_x_values_N = np.arange(-size_of_grid,size_of_grid,polar_grid_resolution)
 grid_y_values_N = np.arange(-size_of_grid,size_of_grid,polar_grid_resolution)
 grid_xx_N,grid_yy_N = np.meshgrid(grid_x_values_N,grid_y_values_N)
 
-grid_lat_coords_N = []
-grid_lon_coords_N = []
-for i in range(grid_xx_N.shape[0]):
-	for j in range(grid_xx_N.shape[1]):
-		lat_point = np.arccos((grid_xx_N[i,j]**2 + grid_yy_N[i,j]**2)**0.5/planet_radius)*180/np.pi
-		lon_point = 180 - np.arctan2(grid_yy_N[i,j],grid_xx_N[i,j])*180/np.pi
-		grid_lat_coords_N.append(lat_point)
-		grid_lon_coords_N.append(lon_point)
+grid_lat_coords_N = (np.arccos((grid_xx_N**2 + grid_yy_N**2)**0.5/planet_radius)*180/np.pi).flatten()
+grid_lon_coords_N = (180 - np.arctan2(grid_yy_N,grid_xx_N)*180/np.pi).flatten()
 
 polar_x_coords_N = []
 polar_y_coords_N = []
@@ -450,19 +435,19 @@ while True:
 
 		before_velocity = time.time()
 		u,v = top_level.velocity_calculation(u,v,w,pressure_levels,geopotential,potential_temperature,coriolis,gravity,dx,dy,dt)
-
+		print('1:', time.time() - before_velocity)
 		u = top_level.smoothing_3D(u,smoothing_parameter_u)
 		v = top_level.smoothing_3D(v,smoothing_parameter_v)
-
+		print('2:', time.time() - before_velocity)
 		w = top_level.w_calculation(u,v,w,pressure_levels,geopotential,potential_temperature,coriolis,gravity,dx,dy,dt)
 		w = top_level.smoothing_3D(w,smoothing_parameter_w,0.25)
-
+		print('3:', time.time() - before_velocity)
 		u[:,:,-1] *= 0.1
 		v[:,:,-1] *= 0.1
 
 		for k in range(nlevels):
 			w[:,:,k] *= pressure_levels[k]/pressure_levels[0]
-		
+		print('4:', time.time() - before_velocity)
 		w[:,:,0] = -w[:,:,1]
 		# w[:,:,2] *= 0.1
 		# w[:,:,3] *= 0.5

--- a/toy_model.py
+++ b/toy_model.py
@@ -437,10 +437,8 @@ while True:
 		u,v = top_level.velocity_calculation(u,v,w,pressure_levels,geopotential,potential_temperature,coriolis,gravity,dx,dy,dt)
 		u = top_level.smoothing_3D(u,smoothing_parameter_u)
 		v = top_level.smoothing_3D(v,smoothing_parameter_v)
-		print('velo 1:', time.time() - before_velocity)
 		w = top_level.w_calculation(u,v,w,pressure_levels,geopotential,potential_temperature,coriolis,gravity,dx,dy,dt)
 		w = top_level.smoothing_3D(w,smoothing_parameter_w,0.25)
-		print('velo 2:', time.time() - before_velocity)
 		u[:,:,-1] *= 0.1
 		v[:,:,-1] *= 0.1
 
@@ -513,7 +511,7 @@ while True:
 			south_temperature_data = potential_temperature[:pole_low_index_S,:,:]
 			south_polar_plane_temperature = beam_me_up(lat[:pole_low_index_S],lon,south_temperature_data,pole_low_index_S,grid_xx_S.shape[0],grid_lat_coords_S,grid_lon_coords_S)
 			south_polar_plane_actual_temperature = low_level.theta_to_t(south_polar_plane_temperature,pressure_levels)
-
+			
 			south_geopotential_data = geopotential[:pole_low_index_S,:,:]
 			south_polar_plane_geopotential = beam_me_up(lat[:pole_low_index_S],lon,south_geopotential_data,pole_low_index_S,grid_xx_S.shape[0],grid_lat_coords_S,grid_lon_coords_S)
 			


### PR DESCRIPTION
These changes drastically improve the speed of the calculations in the main loop by replacing nested for-loops with numpy matrix operations. In general, I replaced many slow for-loops with corresponding matrix operations, always keeping the idea of the original algorithm. This sometimes introduces small numerical differences, which I believe are insignificant. In total, calculations (without plotting) are ~5x faster. Plotting now takes by far the most amount of time in each iteration.

Detailed comparison of performance improvements:
| Part | Improvement |
| --- | --- |
| Radiation | ~35x |
| Velocity | ~20x |
| Advection | ~120x |
| Projection* | ~4x |

\* `grid_velocities_[north|south]` should also be optimized, but I could not wrap my head around the side-effects in the nested for-loops of these functions