### PR TITLE
[Another] Numba acceleration, replacing cython with automatic parallelism

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,6 @@ CLAuDE is currently being developed on Wednesday [Twitch](https://twitch.tv/drsi
 
 ### Licensing
 TODO: Add LICENSE  
+
+### THIS FORK
+The purpose of this fork is to determine what backend/system allows for the easiest speedup.

--- a/claude_low_level_library_numba.py
+++ b/claude_low_level_library_numba.py
@@ -3,7 +3,7 @@
 # claude low level library
 
 import numpy as np
-from numba import njit
+from numba import njit, prange
 
 inv_180 = np.pi/180
 inv_90 = np.pi/90
@@ -11,17 +11,17 @@ sigma = 5.67E-8
 
 # define various useful differential functions:
 # gradient of scalar field a in the local x direction at point i,j
-@njit
+@njit(cache=True)
 def scalar_gradient_x(a, dx, nlon, i, j, k):
 	return (a[i,(j+1)%nlon,k]-a[i,(j-1)%nlon,k])/dx[i]
 
-@njit
+@njit(cache=True)
 def scalar_gradient_x_2D(a, dx, nlon, i, j):
 	return (a[i,(j+1)%nlon]-a[i,(j-1)%nlon])/dx[i]
 
 
 # gradient of scalar field a in the local y direction at point i,j
-@njit
+@njit(cache=True)
 def scalar_gradient_y(a, dy, nlat, i, j, k):
 	if i == 0:
 		return 2*(a[i+1,j,k]-a[i,j,k])/dy
@@ -31,7 +31,7 @@ def scalar_gradient_y(a, dy, nlat, i, j, k):
 		return (a[i+1,j,k]-a[i-1,j,k])/dy
 
 
-@njit
+@njit(cache=True)
 def scalar_gradient_y_2D(dy, nlat, i, j):
 	if i == 0:
 		return 2*(a[i+1,j]-a[i,j])/dy
@@ -40,7 +40,7 @@ def scalar_gradient_y_2D(dy, nlat, i, j):
 	else:
 		return (a[i+1,j]-a[i-1,j])/dy
 
-@njit
+@njit(cache=True)
 def scalar_gradient_z_1D(a, pressure_levels, k):
 	nlevels = len(pressure_levels)
 	if k == 0:
@@ -51,16 +51,16 @@ def scalar_gradient_z_1D(a, pressure_levels, k):
 		return -(a[k+1]-a[k-1])/(pressure_levels[k+1]-pressure_levels[k-1])
 
 
-@njit
+@njit(cache=True)
 def surface_optical_depth(lat):
 	return 4# + np.cos(lat*inv_90)*2
 
-@njit
+@njit(cache=True)
 def thermal_radiation(a):
 	return sigma*(a**4)
 
 # power incident on (lat,lon) at time t
-@njit
+@njit(cache=True)
 def solar(insolation, lat, lon, t, day, year, axial_tilt):
 	sun_longitude = -t % day
 	sun_latitude = axial_tilt*np.cos(t*2*np.pi/year)
@@ -85,28 +85,28 @@ def solar(insolation, lat, lon, t, day, year, axial_tilt):
 		else:
 			return value
 
-@njit
+@njit(cache=True)
 def profile(a):
 	return np.mean(np.mean(a,axis=0),axis=0)
 
-@njit
+@njit(cache=True, parallel=True)
 def t_to_theta(temperature_atmos, pressure_levels):
 	output = np.zeros_like(temperature_atmos)
 	k = 0
 	inv_p0 = 0.0
 
 	inv_p0 = 1/pressure_levels[0]
-	for k in range(len(pressure_levels)):
+	for k in prange(len(pressure_levels)):
 		output[:,:,k] = temperature_atmos[:,:,k]*(pressure_levels[k]*inv_p0)**(-0.286)
 
 	return output
 
-@njit
+@njit(cache=True, parallel=True)
 def theta_to_t(theta, pressure_levels):
 	output = np.zeros_like(theta)
 
 	inv_p0 = 1/pressure_levels[0]
-	for k in range(len(pressure_levels)):
+	for k in prange(len(pressure_levels)):
 		output[:,:,k] = theta[:,:,k]*(pressure_levels[k]*inv_p0)**(0.286)
 
 	return output

--- a/claude_setup.py
+++ b/claude_setup.py
@@ -1,8 +1,0 @@
-from setuptools import setup
-from Cython.Build import cythonize
-import numpy
-
-setup(
-	include_dirs=[numpy.get_include()],
-    ext_modules = cythonize("*.pyx", compiler_directives={'language_level' : "3"})
-)

--- a/claude_top_level_library_numba.py
+++ b/claude_top_level_library_numba.py
@@ -1,70 +1,78 @@
+# claude_high_level_library with Numba acceleration
 # claude_top_level_library
 
-import claude_low_level_library as low_level
+import claude_low_level_library_numba as low_level
 import numpy as np
-cimport numpy as np
-cimport cython
+from numba import jit, njit, prange
+# cimport numpy as np
+# cimport cython
 
-ctypedef np.float64_t DTYPE_f
+# ctypedef np.float64_t DTYPE_f
 
 # laplacian of scalar field a
-cpdef laplacian_2D(np.ndarray a,np.ndarray dx,DTYPE_f dy):
-	cdef np.ndarray output = np.zeros_like(a)
-	cdef np.int_t nlat,nlon,i,j
-	cdef DTYPE_f inv_dx, inv_dy
+@njit
+def laplacian_2d(a, dx, dy):
+	output = np.zeros_like(a)
+	nlat = nlong = i = j = 0;
+	inv_dx = inv_dy = 0.0;
+
 	nlat = a.shape[0]
-	nlon = a.shape[1]
+	nlong = a.shape[1]
 	inv_dy = 1/dy
-	for i in np.arange(1,nlat-1):
+	for i in prange(1, nlat-1):
 		inv_dx = dx[i]
-		for j in range(nlon):
+		for j in prange(nlon):
 			output[i,j] = (low_level.scalar_gradient_x_2D(a,dx,nlon,i,j) - low_level.scalar_gradient_x_2D(a,dx,nlon,i,j))*inv_dx + (low_level.scalar_gradient_y_2D(a,dy,nlat,i+1,j) - low_level.scalar_gradient_y_2D(a,dy,nlat,i-1,j))*inv_dy
 	return output
 
-cpdef laplacian_3D(np.ndarray a,np.ndarray dx,DTYPE_f dy,np.ndarray dz):
-	cdef np.ndarray output = np.zeros_like(a)
-	cdef np.int_t nlat,nlon,nlevels,i,j,k
-	cdef DTYPE_f inv_dx, inv_dy
+@njit
+def laplacian_3d(a, dx, dy, dz):
+	output = np.zeros_like(a)
+	nlat = nlon = nlevels = i = j = k = 0;
+	inv_dx = inv_dy = 0.0;
+
 	nlat = a.shape[0]
-	nlon = a.shape[1]
+	nlong = a.shape[1]
 	nlevels = a.shape[2]
 	inv_dy = 1/dy
-	for i in np.arange(1,nlat-1):
+	for i in prange(1, nlat-1):
 		inv_dx = 1/dx[i]
-		for j in range(nlon):
-			for k in range(nlevels-1):
+		for j in prange(nlon):
+			for k in prange(nlevels-1):
 				output[i,j,k] = (low_level.scalar_gradient_x(a,dx,nlon,i,j,k) - low_level.scalar_gradient_x(a,dx,nlon,i,j,k))*inv_dx + (low_level.scalar_gradient_y(a,dy,nlat,i+1,j,k) - low_level.scalar_gradient_y(a,dy,nlat,i-1,j,k))*inv_dy + (low_level.scalar_gradient_z(a,dz,i,j,k+1)-low_level.scalar_gradient_z(a,dz,i,j,k-1))/(2*dz[k])
-	return output
+	return output				
 
 # divergence of (a*u) where a is a scalar field and u is the atmospheric velocity field
-cpdef divergence_with_scalar(np.ndarray a,np.ndarray u,np.ndarray v,np.ndarray w,np.ndarray dx,DTYPE_f dy,np.ndarray pressure_levels):
-	cdef np.ndarray output = np.zeros_like(a)
-	cdef np.ndarray au, av, aw
-	cdef np.int_t nlat, nlon, nlevels, i, j, k 
+@njit
+def divergence_with_scalar(a, u, v, w, dx, dy, pressure_levels):
+	output = np.zeros_like(a)
+	au = a*u
+	av = a*v
+	aw = a*w
 
 	nlat = output.shape[0]
 	nlon = output.shape[1]
 	nlevels = output.shape[2]
 
-	au = a*u
-	av = a*v
-	aw = a*w
-
-	for i in range(nlat):
-		for j in range(nlon):
-			for k in range(nlevels):
+	for i in prange(nlat):
+		for j in prange(nlon):
+			for k in prange(nlevels):
 				output[i,j,k] = low_level.scalar_gradient_x(au,dx,nlon,i,j,k) + low_level.scalar_gradient_y(av,dy,nlat,i,j,k) + low_level.scalar_gradient_z_1D(aw[i,j,:],pressure_levels,k)
 				
-	return output
+	return output				
 
-cpdef radiation_calculation(np.ndarray temperature_world, np.ndarray potential_temperature, np.ndarray pressure_levels, np.ndarray heat_capacity_earth, np.ndarray albedo, DTYPE_f insolation, np.ndarray lat, np.ndarray lon, np.int_t t, np.int_t dt, DTYPE_f day, DTYPE_f year, DTYPE_f axial_tilt):
+@njit
+def radiation_calculation(temperature_world, potential_temperature, pressure_levels, heat_capacity_earth, albedo, insolation, lat, lon, t, dt, day, year, axial_tilt):
 	# calculate change in temperature of ground and atmosphere due to radiative imbalance
-	cdef np.int_t nlat,nlon,nlevels,i,j,k
-	cdef DTYPE_f fl = 0.1
-	cdef np.ndarray upward_radiation,downward_radiation,optical_depth,Q,temperature_atmos
-	cdef DTYPE_f sun_lat, inv_day
+	nlat = nlon = nlevels = i = j = k = 0
+	fl = 0.1
+
+	# np.ndarray upward_radiation,downward_radiation,optical_depth,Q,temperature_atmos
+
+	sun_lat = inv_day = 0.0
 
 	inv_day = 1/(24*60*60)
+
 
 	temperature_atmos = low_level.theta_to_t(potential_temperature,pressure_levels)
 	nlat = temperature_atmos.shape[0]	
@@ -75,12 +83,12 @@ cpdef radiation_calculation(np.ndarray temperature_world, np.ndarray potential_t
 	downward_radiation = np.zeros(nlevels)
 	Q = np.zeros(nlevels)
 
-	for i in range(nlat):
+	for i in prange(nlat):
 		
 		sun_lat = low_level.surface_optical_depth(lat[i])
 		optical_depth = sun_lat*(fl*(pressure_levels/pressure_levels[0]) + (1-fl)*(pressure_levels/pressure_levels[0])**4)
 		
-		for j in range(nlon):
+		for j in prange(nlon):
 			
 			# calculate upward longwave flux, bc is thermal radiation at surface
 			upward_radiation[0] = low_level.thermal_radiation(temperature_world[i,j])
@@ -106,24 +114,23 @@ cpdef radiation_calculation(np.ndarray temperature_world, np.ndarray potential_t
 	
 	return temperature_world, low_level.t_to_theta(temperature_atmos,pressure_levels)
 
-cpdef velocity_calculation(np.ndarray u,np.ndarray v,np.ndarray w,np.ndarray pressure_levels,np.ndarray geopotential,np.ndarray potential_temperature,np.ndarray coriolis,DTYPE_f gravity,np.ndarray dx,DTYPE_f dy,DTYPE_f dt):
-	
+@njit
+def velocity_calculation(u, v, w, pressure_levels, geopotential, potential_temperature, coriolis, gravity, dx, dy, dt):
 	# introduce temporary arrays to update velocity in the atmosphere
-	cdef np.ndarray u_temp = np.zeros_like(u)
-	cdef np.ndarray v_temp = np.zeros_like(v)
-	cdef np.ndarray w_temp = np.zeros_like(u)
-	cdef np.ndarray temperature_atmos
+	u_temp = np.zeros_like(u)
+	v_temp = np.zeros_like(v)
+	w_temp = np.zeros_like(u)
 
-	cdef np.int_t nlat,nlon,nlevels,i,j,k
+	nlat = nlon = nlevels = i = j = k = 0
 
 	nlat = geopotential.shape[0]
 	nlon = geopotential.shape[1]
 	nlevels = len(pressure_levels)
 
 	# calculate acceleration of atmosphere using primitive equations on beta-plane
-	for i in np.arange(2,nlat-2).tolist():
-		for j in range(nlon):
-			for k in range(nlevels):
+	for i in prange(2,nlat-2):
+		for j in prange(nlon):
+			for k in prange(nlevels):
 				
 				u_temp[i,j,k] += dt*( -u[i,j,k]*low_level.scalar_gradient_x(u,dx,nlon,i,j,k) - v[i,j,k]*low_level.scalar_gradient_y(u,dy,nlat,i,j,k) - w[i,j,k]*low_level.scalar_gradient_z_1D(u[i,j,:],pressure_levels,k) + coriolis[i]*v[i,j,k] - low_level.scalar_gradient_x(geopotential,dx,nlon,i,j,k) - 1E-4*u[i,j,k])
 				v_temp[i,j,k] += dt*( -u[i,j,k]*low_level.scalar_gradient_x(v,dx,nlon,i,j,k) - v[i,j,k]*low_level.scalar_gradient_y(v,dy,nlat,i,j,k) - w[i,j,k]*low_level.scalar_gradient_z_1D(v[i,j,:],pressure_levels,k) - coriolis[i]*u[i,j,k] - low_level.scalar_gradient_y(geopotential,dy,nlat,i,j,k) - 1E-4*v[i,j,k])
@@ -136,32 +143,36 @@ cpdef velocity_calculation(np.ndarray u,np.ndarray v,np.ndarray w,np.ndarray pre
 
 	return u,v
 
-cpdef w_calculation(np.ndarray u,np.ndarray v,np.ndarray w,np.ndarray pressure_levels,np.ndarray geopotential,np.ndarray potential_temperature,np.ndarray coriolis,DTYPE_f gravity,np.ndarray dx,DTYPE_f dy,DTYPE_f dt):
-	cdef np.ndarray w_temp = np.zeros_like(u)
-	cdef np.ndarray temperature_atmos = low_level.theta_to_t(potential_temperature,pressure_levels) 
-	
-	cdef np.int_t nlat,nlon,nlevels,i,j,k
+@njit
+def w_calculation(u, v, w, pressure_levels, geopotential, potential_temperature, coriolis, gravity, dx, dy, dt):
+	w_temp = np.zeros_like(u)
+	temperature_atmos = low_level.theta_to_t(potential_temperature,pressure_levels) 
+
+	nlat = nlon = nlevels = i = j = k = 0
 
 	nlat = geopotential.shape[0]
 	nlon = geopotential.shape[1]
 	nlevels = len(pressure_levels)
 	
-	for i in np.arange(2,nlat-2).tolist():
-		for j in range(nlon):
-			for k in np.arange(1,nlevels).tolist():
+	for i in prange(2,nlat-2):
+		for j in prange(nlon):
+			for k in prange(1,nlevels):
 				w_temp[i,j,k] = w_temp[i,j,k-1] - (pressure_levels[k]-pressure_levels[k-1])*pressure_levels[k]*gravity*( low_level.scalar_gradient_x(u,dx,nlon,i,j,k) + low_level.scalar_gradient_y(v,dy,nlat,i,j,k) )/(287*temperature_atmos[i,j,k])
 
 	w += w_temp
 
-	return w
+	return w	
 
-cpdef smoothing_3D(np.ndarray a,DTYPE_f smooth_parameter, DTYPE_f vert_smooth_parameter=0.5):
-	cdef np.int_t nlat = a.shape[0]
-	cdef np.int_t nlon = a.shape[1]
-	cdef np.int_t nlevels = a.shape[2]
+
+def smoothing_3D(a, smooth_parameter, vert_smooth_parameter=0.5):
+	nlat = a.shape[0]
+	nlon = a.shape[1]
+	nlevels = a.shape[2]
 	smooth_parameter *= 0.5
-	cdef np.ndarray test = np.fft.fftn(a)
+
+	test = np.fft.fftn(a)
 	test[int(nlat*smooth_parameter):int(nlat*(1-smooth_parameter)),:,:] = 0
 	test[:,int(nlon*smooth_parameter):int(nlon*(1-smooth_parameter)),:] = 0
 	test[:,:,int(nlevels*vert_smooth_parameter):int(nlevels*(1-vert_smooth_parameter))] = 0
-	return np.fft.ifftn(test).real
+	return np.fft.ifftn(test).real	
+

--- a/plotting_utils.py
+++ b/plotting_utils.py
@@ -25,8 +25,8 @@ def plotter_thread(q, plots, uvw, latlon, data, misc, flags, pole_indices, grid_
 			test = ax[0].contourf(lon_plot, lat_plot, temperature_world, cmap='seismic')
 			ax[0].streamplot(lon_plot, lat_plot, u[:,:,0], v[:,:,0], color='white',density=1)
 			ax[1].contourf(heights_plot, lat_z_plot, np.transpose(np.mean(low_level.theta_to_t(potential_temperature,pressure_levels),axis=1))[:top,:], cmap='seismic',levels=15)
-			ax[1].contour(heights_plot,lat_z_plot, np.transpose(np.mean(u,axis=1))[:top,:], colors='white',levels=20,linewidths=1,alpha=0.8)
-			ax[1].quiver(heights_plot, lat_z_plot, np.transpose(np.mean(v,axis=1))[:top,:],np.transpose(np.mean(10*w,axis=1))[:top,:],color='black')
+			# ax[1].contour(heights_plot,lat_z_plot, np.transpose(np.mean(u,axis=1))[:top,:], colors='white',levels=20,linewidths=1,alpha=0.8)
+			# ax[1].quiver(heights_plot, lat_z_plot, np.transpose(np.mean(v,axis=1))[:top,:],np.transpose(np.mean(10*w,axis=1))[:top,:],color='black')
 			plt.subplots_adjust(left=0.1, right=0.75)
 			ax[0].set_title('Surface temperature')
 			ax[0].set_xlim(lon.min(),lon.max())
@@ -73,7 +73,7 @@ def plotter_thread(q, plots, uvw, latlon, data, misc, flags, pole_indices, grid_
 		
 		plt.ion()
 		plt.show()
-		plt.pause(2)
+		plt.pause(0.001)
 
 		if not diagnostic:
 			ax[0].cla()
@@ -98,13 +98,14 @@ def plotter_thread(q, plots, uvw, latlon, data, misc, flags, pole_indices, grid_
 
 
 	def update_plot(uvw, data, reprojections, velocity):
-		before_plot = time.time()
+		
 
 		u, v, w = uvw
 		potential_temperature, pressure_levels, atmosp_addition, temperature_world, t, north_temperature_data, north_temperature_resample, north_polar_plane_temperature, south_temperature_data, south_temperature_resample, south_polar_plane_temperature = data
 
 		# update plot
 		if not diagnostic:
+
 			ax[0].contourf(lon_plot, lat_plot, temperature_world, cmap='seismic',levels=15)
 			if velocity:	
 				ax[0].streamplot(lon_plot, lat_plot, u[:,:,0], v[:,:,0], color='white',density=0.75)
@@ -136,7 +137,7 @@ def plotter_thread(q, plots, uvw, latlon, data, misc, flags, pole_indices, grid_
 				skip=(slice(None,None,2),slice(None,None,2))
 				for k, z in zip(range(nplots), level_plots_levels):	
 					z += 1
-					bx[k].contourf(lon_plot, lat_plot, potential_temperature[:,:,z], cmap='seismic',levels=15)
+					bx[k].contourf(  lon_plot, lat_plot, potential_temperature[:,:,z], cmap='seismic',levels=15)
 					bx[k].streamplot(lon_plot, lat_plot, u[:,:,z], v[:,:,z], color='white',density=1.5)
 					bx[k].set_title(str(round(pressure_levels[z]/100))+' hPa')
 					bx[k].set_ylabel('Latitude')
@@ -157,13 +158,15 @@ def plotter_thread(q, plots, uvw, latlon, data, misc, flags, pole_indices, grid_
 				axis.set_yscale('log')
 			f.suptitle( 'Time ' + str(round(t/day,2)) + ' days' )
 
-		time_taken = float(round(time.time() - before_plot,3))
-		print('Threaded Plotting: ',str(time_taken),'s')	
+		
+		
 		if above and velocity and advection:
 			sample = -2
 			gx[0].set_title('Original data')
 			gx[1].set_title('Polar plane')
 			gx[2].set_title('Reprojected data')
+
+			lat_pole_low = lat[pole_low_index_N:]
 
 			# gx[0].contourf(lon,lat[:pole_low_index_S],south_temperature_data[:,:,sample])
 			# gx[1].contourf(grid_x_values_S,grid_y_values_S,south_polar_plane_temperature[:,:,sample])
@@ -171,14 +174,23 @@ def plotter_thread(q, plots, uvw, latlon, data, misc, flags, pole_indices, grid_
 			# gx[2].contourf(lon,lat[:pole_low_index_S],south_temperature_resample[:,:,sample])
 			# gx[2].quiver(lon[::5],lat[:pole_low_index_S],reproj_u_S[:,::5,sample],reproj_v_S[:,::5,sample])
 
-			gx[0].contourf(lon,lat[pole_low_index_N:],north_temperature_data[:,:,sample])
+			gx[0].contourf(lon,lat_pole_low,north_temperature_data[:,:,sample])
 			gx[1].contourf(grid_x_values_N,grid_y_values_N,north_polar_plane_temperature[:,:,sample])
 			gx[1].quiver(grid_x_values_N,grid_y_values_N,x_dot_N[:,:,sample],y_dot_N[:,:,sample])
-			gx[2].contourf(lon,lat[pole_low_index_N:],north_temperature_resample[:,:,sample])
-			gx[2].quiver(lon[::5],lat[pole_low_index_N:],reproj_u_N[:,::5,sample],reproj_v_N[:,::5,sample])
+			gx[2].contourf(lon,lat_pole_low,north_temperature_resample[:,:,sample])
+			gx[2].quiver(lon[::5],lat_pole_low,reproj_u_N[:,::5,sample],reproj_v_N[:,::5,sample])
 		
+		
+
+	
+	for uvw, data, reprojections, velocity in iter(q.get, 'STOP'):
+		before_plot = time.time()
+		print(f"[QUEUE] Len: {q.qsize()}")
+
 		# clear plots
-		if plot or above:	plt.pause(0.01)
+		# if plot or above:
+			# plt.pause(0.01)
+
 		if plot:
 			if not diagnostic:
 				ax[0].cla()
@@ -197,5 +209,9 @@ def plotter_thread(q, plots, uvw, latlon, data, misc, flags, pole_indices, grid_
 			gx[1].cla()
 			gx[2].cla()
 
-	for uvw, data, reprojections, velocity in iter(q.get, 'STOP'):
 		update_plot(uvw, data, reprojections, velocity);
+		f.canvas.draw()
+		f.canvas.flush_events()
+
+		time_taken = float(round(time.time() - before_plot,3))
+		print('Threaded Plotting: ',str(time_taken),'s')	

--- a/plotting_utils.py
+++ b/plotting_utils.py
@@ -78,6 +78,7 @@ def plotter_thread(q, plots, uvw, latlon, data, misc, flags, pole_indices, grid_
 		if not diagnostic:
 			ax[0].cla()
 			ax[1].cla()
+			cbar_ax.cla()
 			if level_plots:
 				for k in range(nplots):
 					bx[k].cla()		

--- a/plotting_utils.py
+++ b/plotting_utils.py
@@ -1,0 +1,201 @@
+import matplotlib.pyplot as plt
+import claude_low_level_library as low_level
+import numpy as np
+import time
+
+
+def plotter_thread(q, plots, uvw, latlon, data, misc, flags, pole_indices, grid_values):
+
+	lon_plot, lat_plot, heights_plot, lat_z_plot, nplots = plots
+	u, v, w = uvw
+	lat, lon = latlon
+	potential_temperature, pressure_levels, atmosp_addition, temperature_world, t = data
+	top, resolution, day = misc
+	above, advection, diagnostic, plot, level_plots = flags
+
+	pole_low_index_N, pole_low_index_S = pole_indices
+	grid_x_values_N, grid_x_values_S, grid_y_values_N, grid_y_values_S = grid_values
+
+
+	if plot:
+		if not diagnostic:
+			# set up plot
+			f, ax = plt.subplots(2,figsize=(9,9))
+			f.canvas.set_window_title('CLAuDE')
+			test = ax[0].contourf(lon_plot, lat_plot, temperature_world, cmap='seismic')
+			ax[0].streamplot(lon_plot, lat_plot, u[:,:,0], v[:,:,0], color='white',density=1)
+			ax[1].contourf(heights_plot, lat_z_plot, np.transpose(np.mean(low_level.theta_to_t(potential_temperature,pressure_levels),axis=1))[:top,:], cmap='seismic',levels=15)
+			ax[1].contour(heights_plot,lat_z_plot, np.transpose(np.mean(u,axis=1))[:top,:], colors='white',levels=20,linewidths=1,alpha=0.8)
+			ax[1].quiver(heights_plot, lat_z_plot, np.transpose(np.mean(v,axis=1))[:top,:],np.transpose(np.mean(10*w,axis=1))[:top,:],color='black')
+			plt.subplots_adjust(left=0.1, right=0.75)
+			ax[0].set_title('Surface temperature')
+			ax[0].set_xlim(lon.min(),lon.max())
+			ax[1].set_title('Atmosphere temperature')
+			ax[1].set_xlim(lat.min(),lat.max())
+			ax[1].set_ylim((pressure_levels.max()/100,pressure_levels[:top].min()/100))
+			ax[1].set_yscale('log')		
+			ax[1].set_ylabel('Pressure (hPa)')
+			ax[1].set_xlabel('Latitude')
+			cbar_ax = f.add_axes([0.85, 0.15, 0.05, 0.7])
+			f.colorbar(test, cax=cbar_ax)
+			cbar_ax.set_title('Temperature (K)')
+			f.suptitle( 'Time ' + str(round(t/day,2)) + ' days' )
+
+			if level_plots:
+
+				level_divisions = int(np.floor(nlevels/nplots))
+				level_plots_levels = range(nlevels)[::level_divisions][::-1]
+
+				g, bx = plt.subplots(nplots,figsize=(9,8),sharex=True)
+				g.canvas.set_window_title('CLAuDE pressure levels')
+				for k, z in zip(range(nplots), level_plots_levels):	
+					z += 1
+					bx[k].contourf(lon_plot, lat_plot, potential_temperature[:,:,z], cmap='seismic')
+					bx[k].set_title(str(pressure_levels[z]/100)+' hPa')
+					bx[k].set_ylabel('Latitude')
+				bx[-1].set_xlabel('Longitude')
+		else:
+			# set up plot
+			f, ax = plt.subplots(2,2,figsize=(9,9))
+			f.canvas.set_window_title('CLAuDE')
+			ax[0,0].contourf(heights_plot, lat_z_plot, np.transpose(np.mean(u,axis=1))[:top,:], cmap='seismic')
+			ax[0,0].set_title('u')
+			ax[0,1].contourf(heights_plot, lat_z_plot, np.transpose(np.mean(v,axis=1))[:top,:], cmap='seismic')
+			ax[0,1].set_title('v')
+			ax[1,0].contourf(heights_plot, lat_z_plot, np.transpose(np.mean(w,axis=1))[:top,:], cmap='seismic')
+			ax[1,0].set_title('w')
+			ax[1,1].contourf(heights_plot, lat_z_plot, np.transpose(np.mean(atmosp_addition,axis=1))[:top,:], cmap='seismic')
+			ax[1,1].set_title('atmosp_addition')
+			for axis in ax.ravel():
+				axis.set_ylim((pressure_levels.max()/100,pressure_levels[:top].min()/100))
+				axis.set_yscale('log')
+			f.suptitle( 'Time ' + str(round(t/day,2)) + ' days' )
+		
+		plt.ion()
+		plt.show()
+		plt.pause(2)
+
+		if not diagnostic:
+			ax[0].cla()
+			ax[1].cla()
+			if level_plots:
+				for k in range(nplots):
+					bx[k].cla()		
+		else:
+			ax[0,0].cla()
+			ax[0,1].cla()	
+			ax[1,0].cla()
+			ax[1,1].cla()
+
+	if above:
+		g,gx = plt.subplots(1,3, figsize=(15,5))
+		plt.ion()
+		plt.show()
+
+
+
+
+
+
+	def update_plot(uvw, data, reprojections, velocity):
+		before_plot = time.time()
+
+		u, v, w = uvw
+		potential_temperature, pressure_levels, atmosp_addition, temperature_world, t, north_temperature_data, north_temperature_resample, north_polar_plane_temperature, south_temperature_data, south_temperature_resample, south_polar_plane_temperature = data
+
+		# update plot
+		if not diagnostic:
+			ax[0].contourf(lon_plot, lat_plot, temperature_world, cmap='seismic',levels=15)
+			if velocity:	
+				ax[0].streamplot(lon_plot, lat_plot, u[:,:,0], v[:,:,0], color='white',density=0.75)
+			ax[0].set_title('$\it{Ground} \quad \it{temperature}$')
+			ax[0].set_xlim((lon.min(),lon.max()))
+			ax[0].set_ylim((lat.min(),lat.max()))
+			ax[0].set_ylabel('Latitude')
+			ax[0].axhline(y=0,color='black',alpha=0.3)
+			ax[0].set_xlabel('Longitude')
+
+			test = ax[1].contourf(heights_plot, lat_z_plot, np.transpose(np.mean(low_level.theta_to_t(potential_temperature,pressure_levels),axis=1))[:top,:], cmap='seismic',levels=15)
+			# test = ax[1].contourf(heights_plot, lat_z_plot, np.transpose(np.mean(potential_temperature,axis=1)), cmap='seismic',levels=15)
+			# test = ax[1].contourf(heights_plot, lat_z_plot, np.transpose(np.mean(v,axis=1))[:top,:], cmap='seismic',levels=15)
+			if velocity:
+				ax[1].contour(heights_plot,lat_z_plot, np.transpose(np.mean(u,axis=1))[:top,:], colors='white',levels=20,linewidths=1,alpha=0.8)
+				ax[1].quiver(heights_plot, lat_z_plot, np.transpose(np.mean(v,axis=1))[:top,:],np.transpose(np.mean(10*w,axis=1))[:top,:],color='black')
+			ax[1].set_title('$\it{Atmospheric} \quad \it{temperature}$')
+			ax[1].set_xlim((-90,90))
+			ax[1].set_ylim((pressure_levels.max()/100,pressure_levels[:top].min()/100))
+			ax[1].set_ylabel('Pressure (hPa)')
+			ax[1].set_xlabel('Latitude')
+			ax[1].set_yscale('log')
+			f.colorbar(test, cax=cbar_ax)
+			cbar_ax.set_title('Temperature (K)')
+			f.suptitle( 'Time ' + str(round(t/day,2)) + ' days' )
+		
+			if level_plots:
+				quiver_padding = int(50/resolution)
+				skip=(slice(None,None,2),slice(None,None,2))
+				for k, z in zip(range(nplots), level_plots_levels):	
+					z += 1
+					bx[k].contourf(lon_plot, lat_plot, potential_temperature[:,:,z], cmap='seismic',levels=15)
+					bx[k].streamplot(lon_plot, lat_plot, u[:,:,z], v[:,:,z], color='white',density=1.5)
+					bx[k].set_title(str(round(pressure_levels[z]/100))+' hPa')
+					bx[k].set_ylabel('Latitude')
+					bx[k].set_xlim((lon.min(),lon.max()))
+					bx[k].set_ylim((lat.min(),lat.max()))				
+				bx[-1].set_xlabel('Longitude')		
+		else:
+			ax[0,0].contourf(heights_plot, lat_z_plot, np.transpose(np.mean(u,axis=1))[:top,:], cmap='seismic')
+			ax[0,0].set_title('u')
+			ax[0,1].contourf(heights_plot, lat_z_plot, np.transpose(np.mean(v,axis=1))[:top,:], cmap='seismic')
+			ax[0,1].set_title('v')
+			ax[1,0].contourf(heights_plot, lat_z_plot, np.transpose(np.mean(w,axis=1))[:top,:], cmap='seismic')
+			ax[1,0].set_title('w')
+			ax[1,1].contourf(heights_plot, lat_z_plot, np.transpose(np.mean(atmosp_addition,axis=1))[:top,:], cmap='seismic')
+			ax[1,1].set_title('atmosp_addition')
+			for axis in ax.ravel():
+				axis.set_ylim((pressure_levels.max()/100,pressure_levels[:top].min()/100))
+				axis.set_yscale('log')
+			f.suptitle( 'Time ' + str(round(t/day,2)) + ' days' )
+
+		time_taken = float(round(time.time() - before_plot,3))
+		print('Threaded Plotting: ',str(time_taken),'s')	
+		if above and velocity and advection:
+			sample = -2
+			gx[0].set_title('Original data')
+			gx[1].set_title('Polar plane')
+			gx[2].set_title('Reprojected data')
+
+			# gx[0].contourf(lon,lat[:pole_low_index_S],south_temperature_data[:,:,sample])
+			# gx[1].contourf(grid_x_values_S,grid_y_values_S,south_polar_plane_temperature[:,:,sample])
+			# gx[1].quiver(grid_x_values_S,grid_y_values_S,x_dot_S[:,:,sample],y_dot_S[:,:,sample])
+			# gx[2].contourf(lon,lat[:pole_low_index_S],south_temperature_resample[:,:,sample])
+			# gx[2].quiver(lon[::5],lat[:pole_low_index_S],reproj_u_S[:,::5,sample],reproj_v_S[:,::5,sample])
+
+			gx[0].contourf(lon,lat[pole_low_index_N:],north_temperature_data[:,:,sample])
+			gx[1].contourf(grid_x_values_N,grid_y_values_N,north_polar_plane_temperature[:,:,sample])
+			gx[1].quiver(grid_x_values_N,grid_y_values_N,x_dot_N[:,:,sample],y_dot_N[:,:,sample])
+			gx[2].contourf(lon,lat[pole_low_index_N:],north_temperature_resample[:,:,sample])
+			gx[2].quiver(lon[::5],lat[pole_low_index_N:],reproj_u_N[:,::5,sample],reproj_v_N[:,::5,sample])
+		
+		# clear plots
+		if plot or above:	plt.pause(0.01)
+		if plot:
+			if not diagnostic:
+				ax[0].cla()
+				ax[1].cla()
+				
+				if level_plots:
+					for k in range(nplots):
+						bx[k].cla()			
+			else:
+				ax[0,0].cla()
+				ax[0,1].cla()
+				ax[1,0].cla()
+				ax[1,1].cla()
+		if above:
+			gx[0].cla()
+			gx[1].cla()
+			gx[2].cla()
+
+	for uvw, data, reprojections, velocity in iter(q.get, 'STOP'):
+		update_plot(uvw, data, reprojections, velocity);

--- a/plotting_utils.py
+++ b/plotting_utils.py
@@ -1,5 +1,5 @@
 import matplotlib.pyplot as plt
-import claude_low_level_library as low_level
+import claude_low_level_library_numba as low_level
 import numpy as np
 import time
 

--- a/toy_model.py
+++ b/toy_model.py
@@ -11,6 +11,10 @@ import claude_top_level_library as top_level
 from scipy.interpolate import interp2d, RectBivariateSpline
 # from twitch import prime_sub
 
+import atexit
+from multiprocessing import Process, Queue
+from plotting_utils import plotter_thread
+
 ######## CONTROL ########
 
 day = 60*60*24					# define length of day (used for calculating Coriolis as well) (s)
@@ -320,6 +324,38 @@ def polar_plane_advect(data,x_dot,y_dot,z_dot,pressure_levels):
 				output[i,j,k] = grid_x_gradient(data_x_dot,i,j,k) + grid_y_gradient(data_y_dot,i,j,k) + grid_p_gradient(data_z_dot,i,j,k,pressure_levels)
 	return output
 
+def init_plot():
+	plots = lon_plot, lat_plot, heights_plot, lat_z_plot, nplots
+	uvw = u, v, w
+	latlon = lat, lon
+	data = potential_temperature, pressure_levels, atmosp_addition, temperature_world, t
+	misc = top, resolution, day
+	flags = above, advection, diagnostic, plot, level_plots
+
+	pole_indices = pole_low_index_N, pole_low_index_S
+	grid_values = grid_x_values_N, grid_x_values_S, grid_y_values_N, grid_y_values_S
+
+
+	q = Queue()
+	p = Process(target=plotter_thread, args=((q, plots, uvw, latlon, data, misc, flags, pole_indices, grid_values)))
+	p.start()
+	atexit.register(p.join)
+	return q
+
+def update_plot():
+
+	uvw = u, v, w
+	data = potential_temperature, pressure_levels, atmosp_addition, temperature_world, t, north_temperature_data, north_temperature_resample, north_polar_plane_temperature, south_temperature_data, south_temperature_resample, south_polar_plane_temperature
+
+
+	reprojections = reproj_u_N, reproj_u_S, reproj_v_N, reproj_v_S
+
+	Q.put([uvw, data, reprojections, velocity]);
+
+def kill_plot():
+	Q.put('stop');
+atexit.register(kill_plot)	
+
 # create Coriolis data on north and south planes
 data = np.zeros((nlat-pole_low_index_N,nlon))
 for i in np.arange(pole_low_index_N,nlat):
@@ -345,80 +381,7 @@ if load:
 	# load in previous save file
 	potential_temperature,temperature_world,u,v,w,t,albedo = pickle.load(open("save_file.p","rb"))
 
-if plot:
-	if not diagnostic:
-		# set up plot
-		f, ax = plt.subplots(2,figsize=(9,9))
-		f.canvas.set_window_title('CLAuDE')
-		test = ax[0].contourf(lon_plot, lat_plot, temperature_world, cmap='seismic')
-		ax[0].streamplot(lon_plot, lat_plot, u[:,:,0], v[:,:,0], color='white',density=1)
-		ax[1].contourf(heights_plot, lat_z_plot, np.transpose(np.mean(low_level.theta_to_t(potential_temperature,pressure_levels),axis=1))[:top,:], cmap='seismic',levels=15)
-		ax[1].contour(heights_plot,lat_z_plot, np.transpose(np.mean(u,axis=1))[:top,:], colors='white',levels=20,linewidths=1,alpha=0.8)
-		ax[1].quiver(heights_plot, lat_z_plot, np.transpose(np.mean(v,axis=1))[:top,:],np.transpose(np.mean(10*w,axis=1))[:top,:],color='black')
-		plt.subplots_adjust(left=0.1, right=0.75)
-		ax[0].set_title('Surface temperature')
-		ax[0].set_xlim(lon.min(),lon.max())
-		ax[1].set_title('Atmosphere temperature')
-		ax[1].set_xlim(lat.min(),lat.max())
-		ax[1].set_ylim((pressure_levels.max()/100,pressure_levels[:top].min()/100))
-		ax[1].set_yscale('log')		
-		ax[1].set_ylabel('Pressure (hPa)')
-		ax[1].set_xlabel('Latitude')
-		cbar_ax = f.add_axes([0.85, 0.15, 0.05, 0.7])
-		f.colorbar(test, cax=cbar_ax)
-		cbar_ax.set_title('Temperature (K)')
-		f.suptitle( 'Time ' + str(round(t/day,2)) + ' days' )
-
-		if level_plots:
-
-			level_divisions = int(np.floor(nlevels/nplots))
-			level_plots_levels = range(nlevels)[::level_divisions][::-1]
-
-			g, bx = plt.subplots(nplots,figsize=(9,8),sharex=True)
-			g.canvas.set_window_title('CLAuDE pressure levels')
-			for k, z in zip(range(nplots), level_plots_levels):	
-				z += 1
-				bx[k].contourf(lon_plot, lat_plot, potential_temperature[:,:,z], cmap='seismic')
-				bx[k].set_title(str(pressure_levels[z]/100)+' hPa')
-				bx[k].set_ylabel('Latitude')
-			bx[-1].set_xlabel('Longitude')
-	else:
-		# set up plot
-		f, ax = plt.subplots(2,2,figsize=(9,9))
-		f.canvas.set_window_title('CLAuDE')
-		ax[0,0].contourf(heights_plot, lat_z_plot, np.transpose(np.mean(u,axis=1))[:top,:], cmap='seismic')
-		ax[0,0].set_title('u')
-		ax[0,1].contourf(heights_plot, lat_z_plot, np.transpose(np.mean(v,axis=1))[:top,:], cmap='seismic')
-		ax[0,1].set_title('v')
-		ax[1,0].contourf(heights_plot, lat_z_plot, np.transpose(np.mean(w,axis=1))[:top,:], cmap='seismic')
-		ax[1,0].set_title('w')
-		ax[1,1].contourf(heights_plot, lat_z_plot, np.transpose(np.mean(atmosp_addition,axis=1))[:top,:], cmap='seismic')
-		ax[1,1].set_title('atmosp_addition')
-		for axis in ax.ravel():
-			axis.set_ylim((pressure_levels.max()/100,pressure_levels[:top].min()/100))
-			axis.set_yscale('log')
-		f.suptitle( 'Time ' + str(round(t/day,2)) + ' days' )
-	
-	plt.ion()
-	plt.show()
-	plt.pause(2)
-
-	if not diagnostic:
-		ax[0].cla()
-		ax[1].cla()
-		if level_plots:
-			for k in range(nplots):
-				bx[k].cla()		
-	else:
-		ax[0,0].cla()
-		ax[0,1].cla()	
-		ax[1,0].cla()
-		ax[1,1].cla()
-
-if above:
-	g,gx = plt.subplots(1,3, figsize=(15,5))
-	plt.ion()
-	plt.show()
+Q = init_plot()
 
 while True:
 
@@ -567,101 +530,7 @@ while True:
 			time_taken = float(round(time.time() - before_projection,3))
 			print('Projection: ',str(time_taken),'s')
 
-	if plot:
-		before_plot = time.time()
-		# update plot
-		if not diagnostic:
-			ax[0].contourf(lon_plot, lat_plot, temperature_world, cmap='seismic',levels=15)
-			if velocity:	
-				ax[0].streamplot(lon_plot, lat_plot, u[:,:,0], v[:,:,0], color='white',density=0.75)
-			ax[0].set_title('$\it{Ground} \quad \it{temperature}$')
-			ax[0].set_xlim((lon.min(),lon.max()))
-			ax[0].set_ylim((lat.min(),lat.max()))
-			ax[0].set_ylabel('Latitude')
-			ax[0].axhline(y=0,color='black',alpha=0.3)
-			ax[0].set_xlabel('Longitude')
-
-			test = ax[1].contourf(heights_plot, lat_z_plot, np.transpose(np.mean(low_level.theta_to_t(potential_temperature,pressure_levels),axis=1))[:top,:], cmap='seismic',levels=15)
-			# test = ax[1].contourf(heights_plot, lat_z_plot, np.transpose(np.mean(potential_temperature,axis=1)), cmap='seismic',levels=15)
-			# test = ax[1].contourf(heights_plot, lat_z_plot, np.transpose(np.mean(v,axis=1))[:top,:], cmap='seismic',levels=15)
-			if velocity:
-				ax[1].contour(heights_plot,lat_z_plot, np.transpose(np.mean(u,axis=1))[:top,:], colors='white',levels=20,linewidths=1,alpha=0.8)
-				ax[1].quiver(heights_plot, lat_z_plot, np.transpose(np.mean(v,axis=1))[:top,:],np.transpose(np.mean(10*w,axis=1))[:top,:],color='black')
-			ax[1].set_title('$\it{Atmospheric} \quad \it{temperature}$')
-			ax[1].set_xlim((-90,90))
-			ax[1].set_ylim((pressure_levels.max()/100,pressure_levels[:top].min()/100))
-			ax[1].set_ylabel('Pressure (hPa)')
-			ax[1].set_xlabel('Latitude')
-			ax[1].set_yscale('log')
-			f.colorbar(test, cax=cbar_ax)
-			cbar_ax.set_title('Temperature (K)')
-			f.suptitle( 'Time ' + str(round(t/day,2)) + ' days' )
-		
-			if level_plots:
-				quiver_padding = int(50/resolution)
-				skip=(slice(None,None,2),slice(None,None,2))
-				for k, z in zip(range(nplots), level_plots_levels):	
-					z += 1
-					bx[k].contourf(lon_plot, lat_plot, potential_temperature[:,:,z], cmap='seismic',levels=15)
-					bx[k].streamplot(lon_plot, lat_plot, u[:,:,z], v[:,:,z], color='white',density=1.5)
-					bx[k].set_title(str(round(pressure_levels[z]/100))+' hPa')
-					bx[k].set_ylabel('Latitude')
-					bx[k].set_xlim((lon.min(),lon.max()))
-					bx[k].set_ylim((lat.min(),lat.max()))				
-				bx[-1].set_xlabel('Longitude')		
-		else:
-			ax[0,0].contourf(heights_plot, lat_z_plot, np.transpose(np.mean(u,axis=1))[:top,:], cmap='seismic')
-			ax[0,0].set_title('u')
-			ax[0,1].contourf(heights_plot, lat_z_plot, np.transpose(np.mean(v,axis=1))[:top,:], cmap='seismic')
-			ax[0,1].set_title('v')
-			ax[1,0].contourf(heights_plot, lat_z_plot, np.transpose(np.mean(w,axis=1))[:top,:], cmap='seismic')
-			ax[1,0].set_title('w')
-			ax[1,1].contourf(heights_plot, lat_z_plot, np.transpose(np.mean(atmosp_addition,axis=1))[:top,:], cmap='seismic')
-			ax[1,1].set_title('atmosp_addition')
-			for axis in ax.ravel():
-				axis.set_ylim((pressure_levels.max()/100,pressure_levels[:top].min()/100))
-				axis.set_yscale('log')
-			f.suptitle( 'Time ' + str(round(t/day,2)) + ' days' )
-
-		time_taken = float(round(time.time() - before_plot,3))
-		print('Plotting: ',str(time_taken),'s')	
-	if above and velocity and advection:
-		sample = -2
-		gx[0].set_title('Original data')
-		gx[1].set_title('Polar plane')
-		gx[2].set_title('Reprojected data')
-
-		# gx[0].contourf(lon,lat[:pole_low_index_S],south_temperature_data[:,:,sample])
-		# gx[1].contourf(grid_x_values_S,grid_y_values_S,south_polar_plane_temperature[:,:,sample])
-		# gx[1].quiver(grid_x_values_S,grid_y_values_S,x_dot_S[:,:,sample],y_dot_S[:,:,sample])
-		# gx[2].contourf(lon,lat[:pole_low_index_S],south_temperature_resample[:,:,sample])
-		# gx[2].quiver(lon[::5],lat[:pole_low_index_S],reproj_u_S[:,::5,sample],reproj_v_S[:,::5,sample])
-
-		gx[0].contourf(lon,lat[pole_low_index_N:],north_temperature_data[:,:,sample])
-		gx[1].contourf(grid_x_values_N,grid_y_values_N,north_polar_plane_temperature[:,:,sample])
-		gx[1].quiver(grid_x_values_N,grid_y_values_N,x_dot_N[:,:,sample],y_dot_N[:,:,sample])
-		gx[2].contourf(lon,lat[pole_low_index_N:],north_temperature_resample[:,:,sample])
-		gx[2].quiver(lon[::5],lat[pole_low_index_N:],reproj_u_N[:,::5,sample],reproj_v_N[:,::5,sample])
-	
-	# clear plots
-	if plot or above:	plt.pause(0.01)
-	if plot:
-		if not diagnostic:
-			ax[0].cla()
-			ax[1].cla()
-			
-			if level_plots:
-				for k in range(nplots):
-					bx[k].cla()			
-		else:
-			ax[0,0].cla()
-			ax[0,1].cla()
-			ax[1,0].cla()
-			ax[1,1].cla()
-	if above:
-		gx[0].cla()
-		gx[1].cla()
-		gx[2].cla()
+	update_plot()
 
 	# advance time by one timesteps
 	t += dt
@@ -674,4 +543,5 @@ while True:
 		pickle.dump((potential_temperature,temperature_world,u,v,w,t,albedo), open("save_file.p","wb"))
 
 	if np.isnan(u.max()):
+		Q.put('STOP');
 		sys.exit()


### PR DESCRIPTION
To address limited performance, two main changes:

## 1. Don't wait for the drawing to finish
Move the matplotlib drawing step to a separate thread. This is responsible for a very significant speedup, but increases complexity (more in Pros/Cons). The single largest contributor to the drawing step is the flow lines, which can't be accelerated without a very significant re-write of matplotlib. This does mean we can compute far more than one step per drawing, which invites higher-resolution models.

## 2. Let Numba manage parallelism
Instead of writing explicitly multi-threaded model evaluation, use the Numba compiler (getting rid of Cython) in ways that allow for automatically managed multi-core execution.

## Pros:
1. Automatic parallelism and optimization without asking for dual fluency in Python and Cython
2. Significantly increased execution speed at every step
3. Headroom for higher-resolution models

## Cons:
1. The matplotlib drawing thread.
    - All plotting data has to get explicitly passed through a multiprocessing Queue.
    - These changes are invisible unless the drawing system needs modified (EG it's build-and-forget).
2. Any common multiprocessing library is going to require knowledge beyond base python, and while Numba is >95% original Python, it's still more complex than no multiprocessing.
