### PR TITLE
Separate Config File from Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -432,3 +432,6 @@ TSWLatexianTemp*
 claude_*_level_library*.pyd
 # and the code it's generated from
 claude_*_level_library.c
+
+# Pycharm Project Files
+.idea/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+    "python.testing.unittestArgs": [
+        "-v",
+        "-s",
+        "./tests",
+        "-p",
+        "test_*.py"
+    ],
+    "python.testing.pytestEnabled": false,
+    "python.testing.nosetestsEnabled": false,
+    "python.testing.unittestEnabled": true
+}

--- a/claude_setup.py
+++ b/claude_setup.py
@@ -3,6 +3,6 @@ from Cython.Build import cythonize
 import numpy
 
 setup(
-	include_dirs=[numpy.get_include()],
-    ext_modules = cythonize("*.pyx", compiler_directives={'language_level' : "3"})
+    include_dirs=[numpy.get_include()],
+    ext_modules=cythonize("*.pyx", compiler_directives={'language_level': "3"})
 )

--- a/config_files/ClaudeConfig.yaml
+++ b/config_files/ClaudeConfig.yaml
@@ -1,0 +1,39 @@
+"planet_config":
+    "day": 86400                        # define length of day (used for calculating Coriolis as well) (s)
+    "year": 365                         # define how many days in a year
+    "resolution": 3                     # how many degrees between latitude and longitude gridpoints
+    "planet_radius": 6.4E6              # define the planet's radius (m)
+    "insolation": 1370                  # TOA radiation from star (W m^-2)
+    "gravity": 9.81                     # define surface gravity for planet (m s^-2)
+    "axial_tilt": 23.5                  # tilt of rotational axis w.r.t. solar plane
+    # Definition of Pressure Levels in Atmosphere
+    "pressure_levels": [1000,950,900,800,700,600,500,400,350,300,250,200,150,100,75,50,25,10,5,2,1]
+
+###
+# you probably won't need this, but there is the option to smooth out fields
+# using FFTs (NB this slows down computation considerably and can introduce nonphysical errors)
+###
+"smoothing_config":
+    smoothing: False
+    smoothing_parameter_t: 1.0
+    smoothing_parameter_u: 0.9
+    smoothing_parameter_v: 0.9
+    smoothing_parameter_w: 0.3
+    smoothing_parameter_add: 0.3
+
+"save_config":
+    save: True # save current state to file?
+    load: True # load initial state from file?
+    save_frequency: 100 # write to file after this many timesteps have passed
+    plot_frequency: 5 # how many timesteps between plots (set this low if you want realtime plots, set this high to improve performance)
+
+"view_config":
+    above: False # display top down view of a pole? showing polar plane data and regular gridded data
+    pole: 'n' # which pole to display - 'n' for north, 's' for south
+    above_level: 16 # which vertical level to display over the pole
+    plot: True # display plots of output?
+    diagnostic: False # display raw fields for diagnostic purposes
+    level_plots: False # display plots of output on vertical levels?
+    nplots: 3 # how many levels you want to see plots of (evenly distributed through column)
+    top: 17 # top pressure level to display (i.e. trim off sponge layer)
+    verbose: False # print times taken to calculate specific processes each timestep

--- a/config_files/DefaultClaudeConfig.yaml
+++ b/config_files/DefaultClaudeConfig.yaml
@@ -1,4 +1,5 @@
-"planet_config":
+--- !ClaudeConfig
+!PlanetConfig "planet_config":
     "hours_in_day": 24                  # define length of day (used for calculating Coriolis as well) (s)
     "days_in_year": 365                 # define how many days in a year
     "resolution": 3                     # how many degrees between latitude and longitude gridpoints
@@ -14,7 +15,7 @@
 # using FFTs (NB this slows down computation considerably and can introduce nonphysical errors)
 # If Smoothing set to false then all other values are optional. Shown here for demonstration purposes
 ###
-"smoothing_config":
+!SmoothingConfig smoothing_config":
     smoothing: False
     smoothing_parameter_t: 1.0
     smoothing_parameter_u: 0.9
@@ -22,13 +23,13 @@
     smoothing_parameter_w: 0.3
     smoothing_parameter_add: 0.3
 
-"save_config":
+!SaveConfig save_config":
     save: True # save current state to file?
     load: True # load initial state from file?
     save_frequency: 100 # write to file after this many timesteps have passed
     plot_frequency: 5 # how many timesteps between plots (set this low if you want realtime plots, set this high to improve performance)
 
-"view_config":
+!ViewConfig "view_config":
     above: False # display top down view of a pole? showing polar plane data and regular gridded data
     pole: 'n' # which pole to display - 'n' for north, 's' for south
     above_level: 16 # which vertical level to display over the pole
@@ -38,3 +39,4 @@
     nplots: 3 # how many levels you want to see plots of (evenly distributed through column)
     top: 17 # top pressure level to display (i.e. trim off sponge layer)
     verbose: False # print times taken to calculate specific processes each timestep
+"""

--- a/config_files/DefaultClaudeConfig.yaml
+++ b/config_files/DefaultClaudeConfig.yaml
@@ -1,6 +1,6 @@
 --- !ClaudeConfig # These are Type Tags to guide config loading and should always be left in
 planet_config: !PlanetConfig
-    hours_in_day: 24                  # define length of day (used for calculating Coriolis as well) (s)
+    hours_in_day: 24                  # define length of day (used for calculating Coriolis as well) (h)
     days_in_year: 365                 # define how many days in a year
     resolution: 3                     # how many degrees between latitude and longitude gridpoints
     planet_radius: 6.4E+6              # define the planet's radius (m)

--- a/config_files/DefaultClaudeConfig.yaml
+++ b/config_files/DefaultClaudeConfig.yaml
@@ -8,8 +8,7 @@ planet_config: !PlanetConfig
     gravity: 9.81                     # define surface gravity for planet (m s^-2)
     axial_tilt: 23.5                  # tilt of rotational axis w.r.t. solar plane
     # Definition of Pressure Levels in Atmosphere
-    pressure_levels: [1000,950,900,800]
-
+    pressure_levels: [1000,950,900,800,700,600,500,400,350,300,250,200,150,100,75,50,25,10,5,2,1]
 ###
 # you probably won't need this, but there is the option to smooth out fields
 # using FFTs (NB this slows down computation considerably and can introduce nonphysical errors)

--- a/config_files/DefaultClaudeConfig.yaml
+++ b/config_files/DefaultClaudeConfig.yaml
@@ -1,6 +1,6 @@
 "planet_config":
-    "day": 86400                        # define length of day (used for calculating Coriolis as well) (s)
-    "year": 365                         # define how many days in a year
+    "hours_in_day": 24                  # define length of day (used for calculating Coriolis as well) (s)
+    "days_in_year": 365                 # define how many days in a year
     "resolution": 3                     # how many degrees between latitude and longitude gridpoints
     "planet_radius": 6.4E6              # define the planet's radius (m)
     "insolation": 1370                  # TOA radiation from star (W m^-2)
@@ -12,6 +12,7 @@
 ###
 # you probably won't need this, but there is the option to smooth out fields
 # using FFTs (NB this slows down computation considerably and can introduce nonphysical errors)
+# If Smoothing set to false then all other values are optional. Shown here for demonstration purposes
 ###
 "smoothing_config":
     smoothing: False

--- a/definitions.py
+++ b/definitions.py
@@ -1,0 +1,4 @@
+import os
+
+ROOT_DIR = os.path.dirname(os.path.abspath(__file__)) # This is your Project Root
+CONFIG_PATH = os.path.join(ROOT_DIR, 'config_files')  # Directory containing Config Files

--- a/model/claude_config.py
+++ b/model/claude_config.py
@@ -99,9 +99,7 @@ class SaveConfig:
         return SaveConfig(
             save=save_config_file.save,
             load=save_config_file.load,
-
             save_frequency=save_config_file.save_frequency,
-
             plot_frequency=save_config_file.plot_frequency
         )
 
@@ -156,7 +154,7 @@ class CoordinateGrid:
     def load_from_file(
         resolution: int,
         top: int,
-        pressure_levels: List[float]
+        pressure_levels: np.ndarray
     ):
         lat = np.arange(-90, 91, resolution)
         lon = np.arange(0, 360, resolution)
@@ -164,11 +162,37 @@ class CoordinateGrid:
         nlon = len(lon)
         lon_plot, lat_plot = np.meshgrid(lon, lat)
         heights_plot, lat_z_plot = np.meshgrid(
-            lat, [x/100 for x in pressure_levels[:top]])
+            lat, pressure_levels[:top]/100)
         temperature_world = np.zeros((nlat, nlon))
+        return CoordinateGrid(
+            lat=lat,
+            lon=lon,
+            nlat=nlat,
+            nlon=nlon,
+            lon_plot=lon_plot,
+            lat_plot=lat_plot,
+            heights_plot=heights_plot,
+            lat_z_plot=lat_z_plot,
+            temperature_world=temperature_world
+        )
 
     def __str__(self):
         return yaml.dump(data=self, Dumper=Dumper)
+
+    def __eq__(self, other):
+        result = False
+        if (isinstance(other, CoordinateGrid)):
+            lat = np.array_equal(self.lat, other.lat)
+            lon = np.array_equal(self.lon, other.lon)
+            nlat = self.nlat == other.nlat
+            nlon = self.nlon == other.nlon
+            lon_plot = np.array_equal(self.lon_plot, other.lon_plot)
+            lat_plot = np.array_equal(self.lat_plot, other.lat_plot)
+            heights_plot = np.array_equal(self.heights_plot, other.heights_plot)
+            lat_z_plot = np.array_equal(self.lat_z_plot, other.lat_z_plot)
+            temperature_world = np.array_equal(self.temperature_world, other.temperature_world)
+            result = lat & lon & nlat & nlon & lon_plot & lat_plot & heights_plot & lat_z_plot & temperature_world
+        return result
 
 
 @dataclass

--- a/model/claude_config.py
+++ b/model/claude_config.py
@@ -5,7 +5,7 @@ from yaml import Loader, Dumper
 from typing import List
 from model.pole_enum import PoleType
 from dataclasses import dataclass
-from model.claude_config_file import *
+from model.claude_config_file import PlanetConfigFile, SaveConfigFile, ViewConfigFile, SmoothingConfigFile, ClaudeConfigFile
 
 
 @dataclass
@@ -37,7 +37,7 @@ class PlanetConfig:
             pressure_levels = np.array_equal(
                 self.pressure_levels, other.pressure_levels)
             nlevels = self.nlevels == other.nlevels
-            result = day & year & resolution & radius & insolation & gravity & axial_tilt & pressure_levels & nlevels
+            result = day and year and resolution and radius and insolation and gravity and axial_tilt and pressure_levels and nlevels
         return result
 
     @staticmethod
@@ -195,7 +195,7 @@ class CoordinateGrid:
             lat_z_plot = np.array_equal(self.lat_z_plot, other.lat_z_plot)
             temperature_world = np.array_equal(
                 self.temperature_world, other.temperature_world)
-            result = lat & lon & nlat & nlon & lon_plot & lat_plot & heights_plot & lat_z_plot & temperature_world
+            result = lat and lon and nlat and nlon and lon_plot and lat_plot and heights_plot and lat_z_plot and temperature_world
         return result
 
 

--- a/model/claude_config.py
+++ b/model/claude_config.py
@@ -10,14 +10,15 @@ from model.claude_config_file import *
 
 @dataclass
 class PlanetConfig:
-    day: int # define length of day (used for calculating Coriolis as well) (s)
-    year: int # length of year (s)
-    resolution: int # how many degrees between latitude and longitude gridpoints
-    planet_radius: float # define the planet's radius (m)
-    insolation: float # TOA radiation from star (W m^-2)
-    gravity: float # define surface gravity for planet (m s^-2)
-    axial_tilt: float # tilt of rotational axis w.r.t. solar plane
-    pressure_levels: np.ndarray # length of year (s)
+    # define length of day (used for calculating Coriolis as well) (s)
+    day: int
+    year: int  # length of year (s)
+    resolution: int  # how many degrees between latitude and longitude gridpoints
+    planet_radius: float  # define the planet's radius (m)
+    insolation: float  # TOA radiation from star (W m^-2)
+    gravity: float  # define surface gravity for planet (m s^-2)
+    axial_tilt: float  # tilt of rotational axis w.r.t. solar plane
+    pressure_levels: np.ndarray  # length of year (s)
     nlevels: int
 
     def __str__(self):
@@ -33,7 +34,8 @@ class PlanetConfig:
             insolation = self.insolation == other.insolation
             gravity = self.gravity == other.gravity
             axial_tilt = self.axial_tilt == other.axial_tilt
-            pressure_levels = np.array_equal(self.pressure_levels, other.pressure_levels)
+            pressure_levels = np.array_equal(
+                self.pressure_levels, other.pressure_levels)
             nlevels = self.nlevels == other.nlevels
             result = day & year & resolution & radius & insolation & gravity & axial_tilt & pressure_levels & nlevels
         return result
@@ -188,9 +190,11 @@ class CoordinateGrid:
             nlon = self.nlon == other.nlon
             lon_plot = np.array_equal(self.lon_plot, other.lon_plot)
             lat_plot = np.array_equal(self.lat_plot, other.lat_plot)
-            heights_plot = np.array_equal(self.heights_plot, other.heights_plot)
+            heights_plot = np.array_equal(
+                self.heights_plot, other.heights_plot)
             lat_z_plot = np.array_equal(self.lat_z_plot, other.lat_z_plot)
-            temperature_world = np.array_equal(self.temperature_world, other.temperature_world)
+            temperature_world = np.array_equal(
+                self.temperature_world, other.temperature_world)
             result = lat & lon & nlat & nlon & lon_plot & lat_plot & heights_plot & lat_z_plot & temperature_world
         return result
 
@@ -210,14 +214,14 @@ class ClaudeConfig:
             claude_config_file.planet_config)
         smoothing_config = SmoothingConfig.load_from_file(
             claude_config_file.smoothing_config)
-        
-        view_config = ViewConfig.load_from_file(
-            claude_config_file.view_config)
+        save_config = SaveConfig.load_from_file(claude_config_file.save_config)
+        view_config = ViewConfig.load_from_file(claude_config_file.view_config)
         coordinate_grid = CoordinateGrid.load_from_file(
             resolution=planet_config.resolution, top=view_config.top, pressure_levels=planet_config.pressure_levels)
         return ClaudeConfig(
             planet_config=planet_config,
             smoothing_config=smoothing_config,
+            save_config=save_config,
             view_config=view_config,
             coordinate_grid=coordinate_grid
         )

--- a/model/claude_config.py
+++ b/model/claude_config.py
@@ -197,12 +197,20 @@ class CoordinateGrid:
 
 @dataclass
 class ClaudeConfig:
+
+    planet_config: PlanetConfig
+    smoothing_config: SmoothingConfig
+    save_config: SaveConfig
+    view_config: ViewConfig
+    coordinate_grid: CoordinateGrid
+
     @staticmethod
     def load_from_file(claude_config_file: ClaudeConfigFile):
         planet_config = PlanetConfig.load_from_file(
             claude_config_file.planet_config)
         smoothing_config = SmoothingConfig.load_from_file(
             claude_config_file.smoothing_config)
+        
         view_config = ViewConfig.load_from_file(
             claude_config_file.view_config)
         coordinate_grid = CoordinateGrid.load_from_file(

--- a/model/claude_config.py
+++ b/model/claude_config.py
@@ -18,7 +18,7 @@ class PlanetConfig:
     insolation: float  # TOA radiation from star (W m^-2)
     gravity: float  # define surface gravity for planet (m s^-2)
     axial_tilt: float  # tilt of rotational axis w.r.t. solar plane
-    pressure_levels: np.ndarray  # length of year (s)
+    pressure_levels: np.ndarray
     nlevels: int
 
     def __str__(self):

--- a/model/claude_config.py
+++ b/model/claude_config.py
@@ -4,7 +4,7 @@ import yaml
 from yaml import Loader, Dumper
 from typing import List
 from model.pole_enum import PoleType
-
+from reprlib import recursive_repr
 
 class PlanetConfig:
     def __init__(self,
@@ -30,8 +30,9 @@ class PlanetConfig:
         self.pressure_levels = pressure_levels
         self.nlevels = len(self.pressure_levels)
 
+    @recursive_repr
     def __repr__(self):
-        return self.__str__()
+        return '<' + '|'.join(map(repr, self)) + '>'()
     
     def __str__(self):
         return yaml.dump(data=self, Dumper=Dumper)
@@ -57,8 +58,9 @@ class SmoothingConfig:
         self.smoothing_parameter_w = smoothing_parameter_w
         self.smoothing_parameter_add = smoothing_parameter_add
     
+    @recursive_repr
     def __repr__(self):
-        return self.__str__()
+        return '<' + '|'.join(map(repr, self)) + '>'
     
     def __str__(self):
         return yaml.dump(data=self, Dumper=Dumper)
@@ -78,8 +80,9 @@ class SaveConfig:
         # how many timesteps between plots (set this low if you want realtime plots, set this high to improve performance)
         self.plot_frequency = plot_frequency
     
+    @recursive_repr
     def __repr__(self):
-        return self.__str__()
+        return '<' + '|'.join(map(repr, self)) + '>'
     
     def __str__(self):
         return yaml.dump(data=self, Dumper=Dumper)
@@ -126,8 +129,9 @@ class CoordinateGrids:
             self.lat, [x/100 for x in pressure_levels[:top]])
         self.temperature_world = np.zeros((self.nlat, self.nlon))
     
+    @recursive_repr
     def __repr__(self):
-        return self.__str__()
+        return '<' + '|'.join(map(repr, self)) + '>'
     
     def __str__(self):
         return yaml.dump(data=self, Dumper=Dumper)
@@ -146,8 +150,9 @@ class ClaudeConfig:
         self.coordinate_grid = CoordinateGrids(
             resolution=self.planet_config.resolution, top=self.view_config.top, pressure_levels=self.planet_config.pressure_levels)
 
+    @recursive_repr
     def __repr__(self):
-        return self.__str__()
+        return '<' + '|'.join(map(repr, self)) + '>'
     
     def __str__(self):
         return yaml.dump(data=self, Dumper=Dumper)

--- a/model/claude_config.py
+++ b/model/claude_config.py
@@ -4,117 +4,128 @@ import yaml
 from yaml import Loader, Dumper
 from typing import List
 from model.pole_enum import PoleType
-from reprlib import recursive_repr
+from dataclasses import dataclass
+from model.claude_config_file import *
 
+
+@dataclass(init=False)
 class PlanetConfig:
+    day: int
+    year: int
+    resolution: int
+    planet_radius: float
+    insolation: float
+    gravity: float
+    axial_tilt: float
+    pressure_levels: List[float]
+    nlevels: int
+
     def __init__(self,
-                 hours_in_day: int,
-                 days_in_year: int,
-                 resolution: int,
-                 planet_radius: float,
-                 insolation: float,
-                 gravity: float,
-                 axial_tilt: float,
-                 pressure_levels: List[float]
+                 planet_config_file: PlanetConfigFile
                  ):
         # define length of day (used for calculating Coriolis as well) (s)
-        self.day = 60 * 60 * hours_in_day
-        self.year = self.day * days_in_year           # length of year (s)
+        self.day = 60 * 60 * planet_config_file.hours_in_day
+        # length of year (s)
+        self.year = self.day * planet_config_file.days_in_year
         # how many degrees between latitude and longitude gridpoints
-        self.resolution = resolution
-        self.planet_radius = planet_radius  # define the planet's radius (m)
-        self.insolation = insolation     # TOA radiation from star (W m^-2)
+        self.resolution = planet_config_file.resolution
+        # define the planet's radius (m)
+        self.planet_radius = planet_config_file.planet_radius
+        # TOA radiation from star (W m^-2)
+        self.insolation = planet_config_file.insolation
         # define surface gravity for planet (m s^-2)
-        self.gravity = gravity
-        self.axial_tilt = axial_tilt      # tilt of rotational axis w.r.t. solar plane
-        self.pressure_levels = pressure_levels
+        self.gravity = planet_config_file.gravity
+        # tilt of rotational axis w.r.t. solar plane
+        self.axial_tilt = planet_config_file.axial_tilt
+        self.pressure_levels = planet_config_file.pressure_levels
         self.nlevels = len(self.pressure_levels)
 
-    @recursive_repr
-    def __repr__(self):
-        return '<' + '|'.join(map(repr, self)) + '>'()
-    
     def __str__(self):
         return yaml.dump(data=self, Dumper=Dumper)
 
-"""
-you probably won't need this, but there is the option to smooth out fields
-using FFTs (NB this slows down computation considerably and can introduce
-nonphysical errors)
-"""
+
+
+@dataclass(init=False)
 class SmoothingConfig:
+    """
+    you probably won't need this, but there is the option to smooth out fields
+    using FFTs (NB this slows down computation considerably and can introduce
+    nonphysical errors)
+    """
+    smoothing: bool
+    smoothing_parameter_t: float
+    smoothing_parameter_u: float
+    smoothing_parameter_v: float
+    smoothing_parameter_w: float
+    smoothing_parameter_add: float
+
     def __init__(self,
-                 smoothing: bool,
-                 smoothing_parameter_t: float,
-                 smoothing_parameter_u: float,
-                 smoothing_parameter_v: float,
-                 smoothing_parameter_w: float,
-                 smoothing_parameter_add: float
+                 smoothing_config_file: SmoothingConfigFile
                  ):
-        self.smoothing = smoothing
-        self.smoothing_parameter_t = smoothing_parameter_t
-        self.smoothing_parameter_u = smoothing_parameter_u
-        self.smoothing_parameter_v = smoothing_parameter_v
-        self.smoothing_parameter_w = smoothing_parameter_w
-        self.smoothing_parameter_add = smoothing_parameter_add
-    
-    @recursive_repr
-    def __repr__(self):
-        return '<' + '|'.join(map(repr, self)) + '>'
-    
+        self.smoothing = smoothing_config_file.smoothing
+        self.smoothing_parameter_t = smoothing_config_file.smoothing_parameter_t
+        self.smoothing_parameter_u = smoothing_config_file.smoothing_parameter_u
+        self.smoothing_parameter_v = smoothing_config_file.smoothing_parameter_v
+        self.smoothing_parameter_w = smoothing_config_file.smoothing_parameter_w
+        self.smoothing_parameter_add = smoothing_config_file.smoothing_parameter_add
+
     def __str__(self):
         return yaml.dump(data=self, Dumper=Dumper)
 
 
+@dataclass(init=False)
 class SaveConfig:
+    save: bool
+    load: bool
+    save_frequency: int
+    plot_frequency: int
+
     def __init__(self,
-                 save: bool,
-                 load: bool,
-                 save_frequency: int,
-                 plot_frequency: int
+                 save_config_file: SaveConfigFile
                  ):
-        self.save = save  # save current state to file?
-        self.load = load  # load initial state from file?
+        self.save = save_config_file.save  # save current state to file?
+        self.load = save_config_file.load  # load initial state from file?
         # write to file after this many timesteps have passed
-        self.save_frequency = save_frequency
+        self.save_frequency = save_config_file.save_frequency
         # how many timesteps between plots (set this low if you want realtime plots, set this high to improve performance)
-        self.plot_frequency = plot_frequency
-    
-    @recursive_repr
-    def __repr__(self):
-        return '<' + '|'.join(map(repr, self)) + '>'
-    
+        self.plot_frequency = save_config_file.plot_frequency
+
     def __str__(self):
         return yaml.dump(data=self, Dumper=Dumper)
 
 
+@dataclass(init=False)
 class ViewConfig:
+
+    above: bool
+    pole: PoleType
+    above_level: int
+    plot: bool
+    diagnostic: bool
+    level_plots: bool
+    nplots: int
+    top: int
+    verbose: bool
+    
     def __init__(self,
-                 above: bool,
-                 pole: PoleType,
-                 above_level: int,
-                 plot: bool,
-                 diagnostic: bool,
-                 level_plots: bool,
-                 nplots: int,
-                 top: int,
-                 verbose: bool
+                 view_config_file: ViewConfigFile
                  ):
         # display top down view of a pole? showing polar plane data and regular gridded data
-        self.above = above
-        self.pole = pole  # which pole to display - 'n' for north, 's' for south
-        self.above_level = above_level  # which vertical level to display over the pole
-        self.plot = plot  # display plots of output?
-        self.diagnostic = diagnostic  # display raw fields for diagnostic purposes
-        self.level_plots = level_plots  # display plots of output on vertical levels?
+        self.above = view_config_file.above
+        self.pole = PoleType(view_config_file.pole)  # which pole to display - 'n' for north, 's' for south
+        self.above_level = view_config_file.above_level  # which vertical level to display over the pole
+        self.plot = view_config_file.plot  # display plots of output?
+        self.diagnostic = view_config_file.diagnostic  # display raw fields for diagnostic purposes
+        self.level_plots = view_config_file.level_plots  # display plots of output on vertical levels?
         # how many levels you want to see plots of (evenly distributed through column)
-        self.nplots = nplots
+        self.nplots = view_config_file.nplots
         # top pressure level to display (i.e. trim off sponge layer)
-        self.top = top
-        self.verbose = verbose  # print times taken to calculate specific processes each timestep
+        self.top = view_config_file.top
+        self.verbose = view_config_file.verbose  # print times taken to calculate specific processes each timestep
 
 
-class CoordinateGrids:
+@dataclass(init=False)
+class CoordinateGrid:
     def __init__(self,
                  resolution: int,
                  top: int,
@@ -128,78 +139,21 @@ class CoordinateGrids:
         self.heights_plot, self.lat_z_plot = np.meshgrid(
             self.lat, [x/100 for x in pressure_levels[:top]])
         self.temperature_world = np.zeros((self.nlat, self.nlon))
-    
-    @recursive_repr
-    def __repr__(self):
-        return '<' + '|'.join(map(repr, self)) + '>'
-    
+
     def __str__(self):
         return yaml.dump(data=self, Dumper=Dumper)
 
 
+@dataclass(init=False)
 class ClaudeConfig:
     def __init__(self,
-                 planet_config: PlanetConfig,
-                 smoothing_config: SmoothingConfig,
-                 save_config: SaveConfig,
-                 view_config: ViewConfig
+                 claude_config_file: ClaudeConfigFile
                  ):
-        self.planet_config = planet_config
-        self.smoothing_config = smoothing_config
-        self.view_config = view_config
-        self.coordinate_grid = CoordinateGrids(
+        self.planet_config = claude_config_file.planet_config
+        self.smoothing_config = claude_config_file.smoothing_config
+        self.view_config = claude_config_file.view_config
+        self.coordinate_grid = CoordinateGrid(
             resolution=self.planet_config.resolution, top=self.view_config.top, pressure_levels=self.planet_config.pressure_levels)
 
-    @recursive_repr
-    def __repr__(self):
-        return '<' + '|'.join(map(repr, self)) + '>'
-    
     def __str__(self):
         return yaml.dump(data=self, Dumper=Dumper)
-
-    @staticmethod
-    def load_from_yaml(data):
-        values = yaml.safe_load(data)
-        planet_config = PlanetConfig(hours_in_day=values["planet_config"]["hours_in_day"],
-                                     days_in_year=values["planet_config"]["days_in_year"],
-                                     resolution=values["planet_config"]["resolution"],
-                                     planet_radius=values["planet_config"]["planet_radius"],
-                                     insolation=values["planet_config"]["insolation"],
-                                     gravity=values["planet_config"]["gravity"],
-                                     axial_tilt=values["planet_config"]["axial_tilt"],
-                                     pressure_levels=values["planet_config"]["pressure_levels"],
-                                     )
-
-        smoothing_config = SmoothingConfig(smoothing=values["smoothing_config"]["smoothing"],
-                                           smoothing_parameter_t=values["smoothing_config"].get(
-                                               "smoothing_parameter_t", None),
-                                           smoothing_parameter_u=values["smoothing_config"].get(
-                                               "smoothing_parameter_u", None),
-                                           smoothing_parameter_v=values["smoothing_config"].get(
-                                                "smoothing_parameter_v", None),
-                                           smoothing_parameter_w=values["smoothing_config"].get(
-                                                "smoothing_parameter_w", None),
-                                           smoothing_parameter_add=values["smoothing_config"].get(
-                                               "smoothing_parameter_add", None)
-                                            )
-
-        save_config = SaveConfig(save=values["save_config"]["save"],
-                                 load=values["save_config"]["load"],
-                                 save_frequency=values["save_config"]["save_frequency"],
-                                 plot_frequency=values["save_config"]["plot_frequency"]
-                                 )
-
-        view_config = ViewConfig(above=values["view_config"]["above"],
-                                 pole=PoleType(values["view_config"]["pole"]),
-                                 above_level=values["view_config"]["above_level"],
-                                 plot=values["view_config"]["plot"],
-                                 diagnostic=values["view_config"]["diagnostic"],
-                                 level_plots=values["view_config"]["level_plots"],
-                                 nplots=values["view_config"]["nplots"],
-                                 top=values["view_config"]["top"],
-                                 verbose=values["view_config"]["verbose"])
-
-        return ClaudeConfig(planet_config=planet_config,
-                            smoothing_config=smoothing_config,
-                            save_config=save_config,
-                            view_config=view_config)

--- a/model/claude_config_file.py
+++ b/model/claude_config_file.py
@@ -3,8 +3,8 @@ import yaml
 
 from yaml import YAMLObject, Dumper
 from typing import List
-from reprlib import recursive_repr
 from dataclasses import dataclass
+
 
 @dataclass
 class PlanetConfigFile(YAMLObject):
@@ -21,6 +21,7 @@ class PlanetConfigFile(YAMLObject):
     def __str__(self):
         return yaml.dump(data=self, Dumper=Dumper)
 
+
 @dataclass
 class SmoothingConfigFile(YAMLObject):
     yaml_tag = u'!SmoothingConfig'
@@ -34,6 +35,7 @@ class SmoothingConfigFile(YAMLObject):
     def __str__(self):
         return yaml.dump(data=self, Dumper=Dumper)
 
+
 @dataclass
 class SaveConfigFile(YAMLObject):
     yaml_tag = u'!SaveConfig'
@@ -44,6 +46,7 @@ class SaveConfigFile(YAMLObject):
 
     def __str__(self):
         return yaml.dump(data=self, Dumper=Dumper)
+
 
 @dataclass
 class ViewConfigFile(YAMLObject):
@@ -61,6 +64,7 @@ class ViewConfigFile(YAMLObject):
 
     def __str__(self):
         return yaml.dump(data=self, Dumper=Dumper)
+
 
 @dataclass
 class ClaudeConfigFile(YAMLObject):

--- a/model/claude_config_file.py
+++ b/model/claude_config_file.py
@@ -21,7 +21,7 @@ class PlanetConfigFile(YAMLObject):
     def __str__(self):
         return yaml.dump(data=self, Dumper=Dumper)
 
-
+@dataclass
 class SmoothingConfigFile(YAMLObject):
     yaml_tag = u'!SmoothingConfig'
     smoothing: bool
@@ -34,7 +34,7 @@ class SmoothingConfigFile(YAMLObject):
     def __str__(self):
         return yaml.dump(data=self, Dumper=Dumper)
 
-
+@dataclass
 class SaveConfigFile(YAMLObject):
     yaml_tag = u'!SaveConfig'
     save: bool
@@ -45,7 +45,7 @@ class SaveConfigFile(YAMLObject):
     def __str__(self):
         return yaml.dump(data=self, Dumper=Dumper)
 
-
+@dataclass
 class ViewConfigFile(YAMLObject):
     yaml_tag = u'!ViewConfig'
 
@@ -62,7 +62,7 @@ class ViewConfigFile(YAMLObject):
     def __str__(self):
         return yaml.dump(data=self, Dumper=Dumper)
 
-
+@dataclass
 class ClaudeConfigFile(YAMLObject):
     yaml_tag = u'!ClaudeConfig'
 

--- a/model/claude_config_file.py
+++ b/model/claude_config_file.py
@@ -1,0 +1,175 @@
+
+import yaml
+
+from yaml import YAMLObject, Dumper
+from typing import List
+from reprlib import recursive_repr
+
+
+class PlanetConfigFile(YAMLObject):
+    yaml_tag = u'!PlanetConfig'
+    hours_in_day: int
+    days_in_year: int
+    resolution: int
+    planet_radius: float
+    insolation: float
+    gravity: float
+    axial_tilt: float
+    pressure_levels: List[float]
+
+    def __init__(self,
+                 hours_in_day: int,
+                 days_in_year: int,
+                 resolution: int,
+                 planet_radius: float,
+                 insolation: float,
+                 gravity: float,
+                 axial_tilt: float,
+                 pressure_levels: List[float]):
+        self.hours_in_day = hours_in_day
+        self.days_in_year = days_in_year
+        self.resolution = resolution
+        self.planet_radius = planet_radius
+        self.insolation = insolation
+        self.gravity = gravity
+        self.axial_tilt = axial_tilt
+        self.pressure_levels = pressure_levels
+
+    @recursive_repr
+    def __repr__(self):
+        return '<' + '|'.join(map(repr, self)) + '>'
+
+    def __str__(self):
+        return yaml.dump(data=self, Dumper=Dumper)
+
+
+class SmoothingConfigFile(YAMLObject):
+    yaml_tag = u'!SmoothingConfig'
+    smoothing: bool
+    smoothing_parameter_t: float
+    smoothing_parameter_u: float
+    smoothing_parameter_v: float
+    smoothing_parameter_w: float
+    smoothing_parameter_add: float
+
+    def __init__(self,
+                 smoothing: bool,
+                 smoothing_parameter_t: float,
+                 smoothing_parameter_u: float,
+                 smoothing_parameter_v: float,
+                 smoothing_parameter_w: float,
+                 smoothing_parameter_add: float
+                 ):
+        self.smoothing = smoothing
+        self.smoothing_parameter_t = smoothing_parameter_t
+        self.smoothing_parameter_u = smoothing_parameter_u
+        self.smoothing_parameter_v = smoothing_parameter_v
+        self.smoothing_parameter_w = smoothing_parameter_w
+        self.smoothing_parameter_add = smoothing_parameter_add
+
+    @recursive_repr
+    def __repr__(self):
+        return '<' + '|'.join(map(repr, self)) + '>'
+
+    def __str__(self):
+        return yaml.dump(data=self, Dumper=Dumper)
+
+
+class SaveConfigFile(YAMLObject):
+    yaml_tag = u'!SaveConfig'
+    save: bool
+    load: bool
+    save_frequency: int
+    plot_frequency: int
+
+    def __init__(self,
+                save: bool,
+                load: bool,
+                save_frequency: int,
+                plot_frequency: int
+                ):
+        self.save = save  # save current state to file?
+        self.load = load  # load initial state from file?
+        # write to file after this many timesteps have passed
+        self.save_frequency = save_frequency
+        # how many timesteps between plots (set this low if you want realtime plots, set this high to improve performance)
+        self.plot_frequency = plot_frequency
+
+    @recursive_repr
+    def __repr__(self):
+        return '<' + '|'.join(map(repr, self)) + '>'
+
+    def __str__(self):
+        return yaml.dump(data=self, Dumper=Dumper)
+
+
+class ViewConfigFile(YAMLObject):
+    yaml_tag = u'!ViewConfig'
+
+    above: bool
+    pole: str
+    above_level: int
+    plot: bool
+    diagnostic: bool
+    level_plots: bool
+    nplots: int
+    top: int
+    verbose: bool
+
+    def __init__(self,
+                 above: bool,
+                 pole: str,
+                 above_level: int,
+                 plot: bool,
+                 diagnostic: bool,
+                 level_plots: bool,
+                 nplots: int,
+                 top: int,
+                 verbose: bool
+                 ):
+        # display top down view of a pole? showing polar plane data and regular gridded data
+        self.above = above
+        self.pole = pole  # which pole to display - 'n' for north, 's' for south
+        self.above_level = above_level  # which vertical level to display over the pole
+        self.plot = plot  # display plots of output?
+        self.diagnostic = diagnostic  # display raw fields for diagnostic purposes
+        self.level_plots = level_plots  # display plots of output on vertical levels?
+        # how many levels you want to see plots of (evenly distributed through column)
+        self.nplots = nplots
+        # top pressure level to display (i.e. trim off sponge layer)
+        self.top = top
+        self.verbose = verbose  # print times taken to calculate specific processes each timestep
+
+
+    @recursive_repr
+    def __repr__(self):
+        return '<' + '|'.join(map(repr, self)) + '>'
+
+    def __str__(self):
+        return yaml.dump(data=self, Dumper=Dumper)
+
+
+class ClaudeConfigFile(YAMLObject):
+    yaml_tag = u'!ClaudeConfig'
+
+    planet_config: PlanetConfigFile
+    smoothing_config: SmoothingConfigFile
+    save_config: SaveConfigFile
+    view_config: ViewConfigFile
+
+    def __init__(self,
+                 planet_config: PlanetConfigFile,
+                 smoothing_config: SmoothingConfigFile,
+                 save_config: SaveConfigFile,
+                 view_config: ViewConfigFile
+                 ):
+        self.planet_config = planet_config
+        self.smoothing_config = smoothing_config
+        self.view_config = view_config
+
+    @recursive_repr
+    def __repr__(self):
+        return '<' + '|'.join(map(repr, self)) + '>'
+
+    def __str__(self):
+        return yaml.dump(data=self, Dumper=Dumper)

--- a/model/claude_config_file.py
+++ b/model/claude_config_file.py
@@ -4,8 +4,9 @@ import yaml
 from yaml import YAMLObject, Dumper
 from typing import List
 from reprlib import recursive_repr
+from dataclasses import dataclass
 
-
+@dataclass
 class PlanetConfigFile(YAMLObject):
     yaml_tag = u'!PlanetConfig'
     hours_in_day: int
@@ -16,28 +17,6 @@ class PlanetConfigFile(YAMLObject):
     gravity: float
     axial_tilt: float
     pressure_levels: List[float]
-
-    def __init__(self,
-                 hours_in_day: int,
-                 days_in_year: int,
-                 resolution: int,
-                 planet_radius: float,
-                 insolation: float,
-                 gravity: float,
-                 axial_tilt: float,
-                 pressure_levels: List[float]):
-        self.hours_in_day = hours_in_day
-        self.days_in_year = days_in_year
-        self.resolution = resolution
-        self.planet_radius = planet_radius
-        self.insolation = insolation
-        self.gravity = gravity
-        self.axial_tilt = axial_tilt
-        self.pressure_levels = pressure_levels
-
-    @recursive_repr
-    def __repr__(self):
-        return '<' + '|'.join(map(repr, self)) + '>'
 
     def __str__(self):
         return yaml.dump(data=self, Dumper=Dumper)
@@ -52,25 +31,6 @@ class SmoothingConfigFile(YAMLObject):
     smoothing_parameter_w: float
     smoothing_parameter_add: float
 
-    def __init__(self,
-                 smoothing: bool,
-                 smoothing_parameter_t: float,
-                 smoothing_parameter_u: float,
-                 smoothing_parameter_v: float,
-                 smoothing_parameter_w: float,
-                 smoothing_parameter_add: float
-                 ):
-        self.smoothing = smoothing
-        self.smoothing_parameter_t = smoothing_parameter_t
-        self.smoothing_parameter_u = smoothing_parameter_u
-        self.smoothing_parameter_v = smoothing_parameter_v
-        self.smoothing_parameter_w = smoothing_parameter_w
-        self.smoothing_parameter_add = smoothing_parameter_add
-
-    @recursive_repr
-    def __repr__(self):
-        return '<' + '|'.join(map(repr, self)) + '>'
-
     def __str__(self):
         return yaml.dump(data=self, Dumper=Dumper)
 
@@ -81,23 +41,6 @@ class SaveConfigFile(YAMLObject):
     load: bool
     save_frequency: int
     plot_frequency: int
-
-    def __init__(self,
-                save: bool,
-                load: bool,
-                save_frequency: int,
-                plot_frequency: int
-                ):
-        self.save = save  # save current state to file?
-        self.load = load  # load initial state from file?
-        # write to file after this many timesteps have passed
-        self.save_frequency = save_frequency
-        # how many timesteps between plots (set this low if you want realtime plots, set this high to improve performance)
-        self.plot_frequency = plot_frequency
-
-    @recursive_repr
-    def __repr__(self):
-        return '<' + '|'.join(map(repr, self)) + '>'
 
     def __str__(self):
         return yaml.dump(data=self, Dumper=Dumper)
@@ -116,35 +59,6 @@ class ViewConfigFile(YAMLObject):
     top: int
     verbose: bool
 
-    def __init__(self,
-                 above: bool,
-                 pole: str,
-                 above_level: int,
-                 plot: bool,
-                 diagnostic: bool,
-                 level_plots: bool,
-                 nplots: int,
-                 top: int,
-                 verbose: bool
-                 ):
-        # display top down view of a pole? showing polar plane data and regular gridded data
-        self.above = above
-        self.pole = pole  # which pole to display - 'n' for north, 's' for south
-        self.above_level = above_level  # which vertical level to display over the pole
-        self.plot = plot  # display plots of output?
-        self.diagnostic = diagnostic  # display raw fields for diagnostic purposes
-        self.level_plots = level_plots  # display plots of output on vertical levels?
-        # how many levels you want to see plots of (evenly distributed through column)
-        self.nplots = nplots
-        # top pressure level to display (i.e. trim off sponge layer)
-        self.top = top
-        self.verbose = verbose  # print times taken to calculate specific processes each timestep
-
-
-    @recursive_repr
-    def __repr__(self):
-        return '<' + '|'.join(map(repr, self)) + '>'
-
     def __str__(self):
         return yaml.dump(data=self, Dumper=Dumper)
 
@@ -156,20 +70,6 @@ class ClaudeConfigFile(YAMLObject):
     smoothing_config: SmoothingConfigFile
     save_config: SaveConfigFile
     view_config: ViewConfigFile
-
-    def __init__(self,
-                 planet_config: PlanetConfigFile,
-                 smoothing_config: SmoothingConfigFile,
-                 save_config: SaveConfigFile,
-                 view_config: ViewConfigFile
-                 ):
-        self.planet_config = planet_config
-        self.smoothing_config = smoothing_config
-        self.view_config = view_config
-
-    @recursive_repr
-    def __repr__(self):
-        return '<' + '|'.join(map(repr, self)) + '>'
 
     def __str__(self):
         return yaml.dump(data=self, Dumper=Dumper)

--- a/model/config.py
+++ b/model/config.py
@@ -1,0 +1,102 @@
+import numpy as np 
+from model.pole_enum import PoleEnum
+
+class PlanetProperties:
+    def __init__(self,
+        day: int,
+        year: int,
+        resolution: int,
+        planet_radius: float,
+        insolation: float,
+        gravity: float,
+        axial_tilt: float,
+        pressure_levels: list(float)
+    ):
+        self.day = day      # define length of day (used for calculating Coriolis as well) (s)
+        self.year           # length of year (s)
+        self.resolution = resolution     # how many degrees between latitude and longitude gridpoints
+        self.planet_radius = planet_radius  # define the planet's radius (m)
+        self.insolation = insolation     # TOA radiation from star (W m^-2)
+        self.gravity = gravity        # define surface gravity for planet (m s^-2)
+        self.axial_tilt = axial_tilt      # tilt of rotational axis w.r.t. solar plane
+        self.pressure_levels = pressure_levels
+        self.nlevels = len(self.pressure_levels)
+
+"""
+you probably won't need this, but there is the option to smooth out fields
+using FFTs (NB this slows down computation considerably and can introduce
+nonphysical errors)
+"""
+class SmoothingConfig: 
+    def __init__(self,
+        smoothing: bool,
+        smoothing_parameter_t: float,
+        smoothing_parameter_u: float,
+        smoothing_parameter_v: float,
+        smoothing_parameter_w: float,
+        smoothing_parameter_add: float
+    ):
+        self.smoothing = smoothing
+        self.smoothing_parameter_t = smoothing_parameter_t
+        self.smoothing_parameter_u = smoothing_parameter_u
+        self.smoothing_parameter_v = smoothing_parameter_v
+        self.smoothing_parameter_w = smoothing_parameter_w
+        self.smoothing_parameter_add = smoothing_parameter_add
+
+class SaveConfig:
+    def __init__(self,
+        save: bool,
+        load: bool,
+        save_frequency: int,
+        plot_frequency: int
+    ): 
+        self.save = save # save current state to file?
+        self.load = load # load initial state from file?
+        self.save_frequency = save_frequency # write to file after this many timesteps have passed
+        self.plot_frequency = plot_frequency # how many timesteps between plots (set this low if you want realtime plots, set this high to improve performance)
+
+class ViewConfig:
+    def __init__(self,
+        above: bool,
+        pole: PoleEnum,
+        above_level: int,
+        plot: bool,
+        diagnostic: bool,
+        level_plots: bool,
+        nplots: int,
+        top: int,
+        verbose: bool
+    ):
+        self.above = above # display top down view of a pole? showing polar plane data and regular gridded data
+        self.pole = pole # which pole to display - 'n' for north, 's' for south
+        self.above_level = above_level # which vertical level to display over the pole
+        self.plot = plot # display plots of output?
+        self.diagnostic = diagnostic # display raw fields for diagnostic purposes
+        self.level_plots = level_plots # display plots of output on vertical levels?
+        self.nplots = nplots # how many levels you want to see plots of (evenly distributed through column)
+        self.top = top # top pressure level to display (i.e. trim off sponge layer)
+        self.verbose = verbose # print times taken to calculate specific processes each timestep
+
+class CoordinateGrids:
+    def __init__(self,
+        resolution: int,
+        top: int
+    ):
+        self.lat = np.arange(-90,91,resolution)
+        self.lon = np.arange(0,360,resolution)
+        self.nlat = len(self.lat)
+        self.nlon = len(self.lon)
+        self.lon_plot, self.lat_plot = np.meshgrid(self.lon, self.lat)
+        self.heights_plot, self.lat_z_plot = np.meshgrid(self.lat, self.pressure_levels[:top]/100)
+        self.temperature_world = np.zeros((self.nlat, self.nlon))
+
+class ClaudeConfig:
+    def __init__(self,
+        planet_properties: PlanetProperties,
+        smoothing_config: SmoothingConfig,
+        view_config: ViewConfig
+    ):
+        self.planet_properties = planet_properties
+        self.smoothing_config = smoothing_config
+        self.view_config = view_config
+        self.coordinate_grid = CoordinateGrids(resolution = self.planet_properties.resolution, top = self.planet_properties.top)

--- a/model/config.py
+++ b/model/config.py
@@ -1,117 +1,200 @@
 import numpy as np
 import yaml
 
-from model.pole_enum import PoleEnum
+from yaml import Loader, Dumper
+from typing import List
+from model.pole_enum import PoleType
+
 
 class PlanetConfig:
     def __init__(self,
-        day: int,
-        year: int,
-        resolution: int,
-        planet_radius: float,
-        insolation: float,
-        gravity: float,
-        axial_tilt: float,
-        pressure_levels: list(float)
-    ):
-        self.day = day      # define length of day (used for calculating Coriolis as well) (s)
-        self.year = day * year           # length of year (s)
-        self.resolution = resolution     # how many degrees between latitude and longitude gridpoints
+                 hours_in_day: int,
+                 days_in_year: int,
+                 resolution: int,
+                 planet_radius: float,
+                 insolation: float,
+                 gravity: float,
+                 axial_tilt: float,
+                 pressure_levels: List[float]
+                 ):
+        # define length of day (used for calculating Coriolis as well) (s)
+        self.day = 60 * 60 * hours_in_day
+        self.year = self.day * days_in_year           # length of year (s)
+        # how many degrees between latitude and longitude gridpoints
+        self.resolution = resolution
         self.planet_radius = planet_radius  # define the planet's radius (m)
         self.insolation = insolation     # TOA radiation from star (W m^-2)
-        self.gravity = gravity        # define surface gravity for planet (m s^-2)
+        # define surface gravity for planet (m s^-2)
+        self.gravity = gravity
         self.axial_tilt = axial_tilt      # tilt of rotational axis w.r.t. solar plane
         self.pressure_levels = pressure_levels
         self.nlevels = len(self.pressure_levels)
+
+    def __repr__(self):
+        return self.__str__()
+    
+    def __str__(self):
+        return yaml.dump(data=self, Dumper=Dumper)
 
 """
 you probably won't need this, but there is the option to smooth out fields
 using FFTs (NB this slows down computation considerably and can introduce
 nonphysical errors)
 """
-class SmoothingConfig: 
+class SmoothingConfig:
     def __init__(self,
-        smoothing: bool,
-        smoothing_parameter_t: float,
-        smoothing_parameter_u: float,
-        smoothing_parameter_v: float,
-        smoothing_parameter_w: float,
-        smoothing_parameter_add: float
-    ):
+                 smoothing: bool,
+                 smoothing_parameter_t: float,
+                 smoothing_parameter_u: float,
+                 smoothing_parameter_v: float,
+                 smoothing_parameter_w: float,
+                 smoothing_parameter_add: float
+                 ):
         self.smoothing = smoothing
         self.smoothing_parameter_t = smoothing_parameter_t
         self.smoothing_parameter_u = smoothing_parameter_u
         self.smoothing_parameter_v = smoothing_parameter_v
         self.smoothing_parameter_w = smoothing_parameter_w
         self.smoothing_parameter_add = smoothing_parameter_add
+    
+    def __repr__(self):
+        return self.__str__()
+    
+    def __str__(self):
+        return yaml.dump(data=self, Dumper=Dumper)
+
 
 class SaveConfig:
     def __init__(self,
-        save: bool,
-        load: bool,
-        save_frequency: int,
-        plot_frequency: int
-    ): 
-        self.save = save # save current state to file?
-        self.load = load # load initial state from file?
-        self.save_frequency = save_frequency # write to file after this many timesteps have passed
-        self.plot_frequency = plot_frequency # how many timesteps between plots (set this low if you want realtime plots, set this high to improve performance)
+                 save: bool,
+                 load: bool,
+                 save_frequency: int,
+                 plot_frequency: int
+                 ):
+        self.save = save  # save current state to file?
+        self.load = load  # load initial state from file?
+        # write to file after this many timesteps have passed
+        self.save_frequency = save_frequency
+        # how many timesteps between plots (set this low if you want realtime plots, set this high to improve performance)
+        self.plot_frequency = plot_frequency
+    
+    def __repr__(self):
+        return self.__str__()
+    
+    def __str__(self):
+        return yaml.dump(data=self, Dumper=Dumper)
+
 
 class ViewConfig:
     def __init__(self,
-        above: bool,
-        pole: PoleEnum,
-        above_level: int,
-        plot: bool,
-        diagnostic: bool,
-        level_plots: bool,
-        nplots: int,
-        top: int,
-        verbose: bool
-    ):
-        self.above = above # display top down view of a pole? showing polar plane data and regular gridded data
-        self.pole = pole # which pole to display - 'n' for north, 's' for south
-        self.above_level = above_level # which vertical level to display over the pole
-        self.plot = plot # display plots of output?
-        self.diagnostic = diagnostic # display raw fields for diagnostic purposes
-        self.level_plots = level_plots # display plots of output on vertical levels?
-        self.nplots = nplots # how many levels you want to see plots of (evenly distributed through column)
-        self.top = top # top pressure level to display (i.e. trim off sponge layer)
-        self.verbose = verbose # print times taken to calculate specific processes each timestep
+                 above: bool,
+                 pole: PoleType,
+                 above_level: int,
+                 plot: bool,
+                 diagnostic: bool,
+                 level_plots: bool,
+                 nplots: int,
+                 top: int,
+                 verbose: bool
+                 ):
+        # display top down view of a pole? showing polar plane data and regular gridded data
+        self.above = above
+        self.pole = pole  # which pole to display - 'n' for north, 's' for south
+        self.above_level = above_level  # which vertical level to display over the pole
+        self.plot = plot  # display plots of output?
+        self.diagnostic = diagnostic  # display raw fields for diagnostic purposes
+        self.level_plots = level_plots  # display plots of output on vertical levels?
+        # how many levels you want to see plots of (evenly distributed through column)
+        self.nplots = nplots
+        # top pressure level to display (i.e. trim off sponge layer)
+        self.top = top
+        self.verbose = verbose  # print times taken to calculate specific processes each timestep
+
 
 class CoordinateGrids:
     def __init__(self,
-        resolution: int,
-        top: int
-    ):
-        self.lat = np.arange(-90,91,resolution)
-        self.lon = np.arange(0,360,resolution)
+                 resolution: int,
+                 top: int,
+                 pressure_levels: List[float]
+                 ):
+        self.lat = np.arange(-90, 91, resolution)
+        self.lon = np.arange(0, 360, resolution)
         self.nlat = len(self.lat)
         self.nlon = len(self.lon)
         self.lon_plot, self.lat_plot = np.meshgrid(self.lon, self.lat)
-        self.heights_plot, self.lat_z_plot = np.meshgrid(self.lat, self.pressure_levels[:top]/100)
+        self.heights_plot, self.lat_z_plot = np.meshgrid(
+            self.lat, [x/100 for x in pressure_levels[:top]])
         self.temperature_world = np.zeros((self.nlat, self.nlon))
+    
+    def __repr__(self):
+        return self.__str__()
+    
+    def __str__(self):
+        return yaml.dump(data=self, Dumper=Dumper)
+
 
 class ClaudeConfig:
     def __init__(self,
-        planet_config: PlanetConfig,
-        smoothing_config: SmoothingConfig,
-        save_config: SaveConfig,
-        view_config: ViewConfig
-    ):
+                 planet_config: PlanetConfig,
+                 smoothing_config: SmoothingConfig,
+                 save_config: SaveConfig,
+                 view_config: ViewConfig
+                 ):
         self.planet_config = planet_config
         self.smoothing_config = smoothing_config
         self.view_config = view_config
-        self.coordinate_grid = CoordinateGrids(resolution=self.planet_config.resolution, top=self.planet_config.top)
+        self.coordinate_grid = CoordinateGrids(
+            resolution=self.planet_config.resolution, top=self.view_config.top, pressure_levels=self.planet_config.pressure_levels)
+
+    def __repr__(self):
+        return self.__str__()
+    
+    def __str__(self):
+        return yaml.dump(data=self, Dumper=Dumper)
 
     @staticmethod
     def load_from_yaml(data):
         values = yaml.safe_load(data)
-        planet_config = PlanetConfig(data["planet_config"])
-        smoothing_config = SmoothingConfig(data["smoothing_config"])
-        save_config = SaveConfig(data["save_config"])
-        view_config = ViewConfig(data["view_config"])
+        planet_config = PlanetConfig(hours_in_day=values["planet_config"]["hours_in_day"],
+                                     days_in_year=values["planet_config"]["days_in_year"],
+                                     resolution=values["planet_config"]["resolution"],
+                                     planet_radius=values["planet_config"]["planet_radius"],
+                                     insolation=values["planet_config"]["insolation"],
+                                     gravity=values["planet_config"]["gravity"],
+                                     axial_tilt=values["planet_config"]["axial_tilt"],
+                                     pressure_levels=values["planet_config"]["pressure_levels"],
+                                     )
+
+        smoothing_config = SmoothingConfig(smoothing=values["smoothing_config"]["smoothing"],
+                                           smoothing_parameter_t=values["smoothing_config"].get(
+                                               "smoothing_parameter_t", None),
+                                           smoothing_parameter_u=values["smoothing_config"].get(
+                                               "smoothing_parameter_u", None),
+                                           smoothing_parameter_v=values["smoothing_config"].get(
+                                                "smoothing_parameter_v", None),
+                                           smoothing_parameter_w=values["smoothing_config"].get(
+                                                "smoothing_parameter_w", None),
+                                           smoothing_parameter_add=values["smoothing_config"].get(
+                                               "smoothing_parameter_add", None)
+                                            )
+
+        save_config = SaveConfig(save=values["save_config"]["save"],
+                                 load=values["save_config"]["load"],
+                                 save_frequency=values["save_config"]["save_frequency"],
+                                 plot_frequency=values["save_config"]["plot_frequency"]
+                                 )
+
+        view_config = ViewConfig(above=values["view_config"]["above"],
+                                 pole=PoleType(values["view_config"]["pole"]),
+                                 above_level=values["view_config"]["above_level"],
+                                 plot=values["view_config"]["plot"],
+                                 diagnostic=values["view_config"]["diagnostic"],
+                                 level_plots=values["view_config"]["level_plots"],
+                                 nplots=values["view_config"]["nplots"],
+                                 top=values["view_config"]["top"],
+                                 verbose=values["view_config"]["verbose"])
+
         return ClaudeConfig(planet_config=planet_config,
-            smoothing_config=smoothing_config,
-            save_config=save_config,
-            view_config=view_config)
+                            smoothing_config=smoothing_config,
+                            save_config=save_config,
+                            view_config=view_config)

--- a/model/config.py
+++ b/model/config.py
@@ -1,7 +1,9 @@
-import numpy as np 
+import numpy as np
+import yaml
+
 from model.pole_enum import PoleEnum
 
-class PlanetProperties:
+class PlanetConfig:
     def __init__(self,
         day: int,
         year: int,
@@ -13,7 +15,7 @@ class PlanetProperties:
         pressure_levels: list(float)
     ):
         self.day = day      # define length of day (used for calculating Coriolis as well) (s)
-        self.year           # length of year (s)
+        self.year = day * year           # length of year (s)
         self.resolution = resolution     # how many degrees between latitude and longitude gridpoints
         self.planet_radius = planet_radius  # define the planet's radius (m)
         self.insolation = insolation     # TOA radiation from star (W m^-2)
@@ -92,11 +94,24 @@ class CoordinateGrids:
 
 class ClaudeConfig:
     def __init__(self,
-        planet_properties: PlanetProperties,
+        planet_config: PlanetConfig,
         smoothing_config: SmoothingConfig,
+        save_config: SaveConfig,
         view_config: ViewConfig
     ):
-        self.planet_properties = planet_properties
+        self.planet_config = planet_config
         self.smoothing_config = smoothing_config
         self.view_config = view_config
-        self.coordinate_grid = CoordinateGrids(resolution = self.planet_properties.resolution, top = self.planet_properties.top)
+        self.coordinate_grid = CoordinateGrids(resolution=self.planet_config.resolution, top=self.planet_config.top)
+
+    @staticmethod
+    def load_from_yaml(data):
+        values = yaml.safe_load(data)
+        planet_config = PlanetConfig(data["planet_config"])
+        smoothing_config = SmoothingConfig(data["smoothing_config"])
+        save_config = SaveConfig(data["save_config"])
+        view_config = ViewConfig(data["view_config"])
+        return ClaudeConfig(planet_config=planet_config,
+            smoothing_config=smoothing_config,
+            save_config=save_config,
+            view_config=view_config)

--- a/model/pole_enum.py
+++ b/model/pole_enum.py
@@ -1,0 +1,5 @@
+from enum import Enum
+
+class Pole(Enum):
+    NORTH = 'n'
+    SOUTH = 's'

--- a/model/pole_enum.py
+++ b/model/pole_enum.py
@@ -1,5 +1,5 @@
 from enum import Enum
 
-class Pole(Enum):
+class PoleType(Enum):
     NORTH = 'n'
     SOUTH = 's'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy
 matplotlib
 scipy
+pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy
 matplotlib
 scipy
 pyyaml
+Cython

--- a/tests/model_tests/test_claude_config.py
+++ b/tests/model_tests/test_claude_config.py
@@ -1,10 +1,11 @@
-import dataclasses, unittest
+import dataclasses
+import unittest
 
 import numpy as np
 
 from definitions import CONFIG_PATH
 from model.claude_config_file import PlanetConfigFile
-from model.claude_config import *
+from model.claude_config import PlanetConfig, SmoothingConfig, SaveConfig, ViewConfig, CoordinateGrid, ClaudeConfig
 
 
 class TestPlanetConfig(unittest.TestCase):
@@ -474,6 +475,7 @@ class TestClaudeConfig(unittest.TestCase):
             view_config=expected_view_config,
             coordinate_grid=expected_coordinate_grid)
 
-        result_claude_config = ClaudeConfig.load_from_file(test_claude_config_file)
+        result_claude_config = ClaudeConfig.load_from_file(
+            test_claude_config_file)
 
         self.assertEquals(result_claude_config, expected_claude_config)

--- a/tests/model_tests/test_claude_config.py
+++ b/tests/model_tests/test_claude_config.py
@@ -1,9 +1,113 @@
+import dataclasses
 import unittest, os
+import numpy as np 
+
 from definitions import CONFIG_PATH
+from model.claude_config_file import PlanetConfigFile
+from model.claude_config import PlanetConfig, ClaudeConfig
 
-from model.claude_config import ClaudeConfig
+class TestPlanetConfig(unittest.TestCase):
 
-class TestClaudeConfig(unittest.TestCase):
+    def test_equals_all_same(self):
+        day=3600
+        year=7200
+        resolution=3
+        planet_radius=4000
+        insolation=10
+        gravity=9.2
+        axial_tilt=20.0
+        pressure_levels=np.array([10000,20000,30000])
+        nlevels=3
 
-    def test_yaml_load(self):
-        pass
+        config1 = PlanetConfig(
+            day,
+            year,
+            resolution,
+            planet_radius,
+            insolation,
+            gravity,
+            axial_tilt,
+            pressure_levels,
+            nlevels
+        )
+        config2 = PlanetConfig(
+            day,
+            year,
+            resolution,
+            planet_radius,
+            insolation,
+            gravity,
+            axial_tilt,
+            pressure_levels,
+            nlevels
+        )
+
+        self.assertTrue(config1 == config2)
+    
+    def test_equals_one_var_diffs(self):
+        
+        test_data = {
+            "day":[3600,2500],
+            "year":[7200,3600],
+            "resolution":[3,4],
+            "planet_radius":[4000,5000],
+            "insolation":[10,8],
+            "gravity":[9.2,7.2],
+            "axial_tilt":[20.0,15.2],
+            "pressure_levels":[np.array([10000,20000,30000]),np.array([1000, 2000, 3000])],
+            "nlevels":[3,4]
+        }
+
+        config1 = PlanetConfig(
+            test_data["day"][0],
+            test_data["year"][0],
+            test_data["resolution"][0],
+            test_data["planet_radius"][0],
+            test_data["insolation"][0],
+            test_data["gravity"][0],
+            test_data["axial_tilt"][0],
+            test_data["pressure_levels"][0],
+            test_data["nlevels"][0]
+        )
+
+        for field in dataclasses.fields(PlanetConfig):
+            config2 = PlanetConfig(
+                test_data["day"][1 if field.name=="day" else 0],
+                test_data["year"][1 if field.name=="year" else 0],
+                test_data["resolution"][1 if field.name=="resolution" else 0],
+                test_data["planet_radius"][1 if field.name=="planet_radius" else 0],
+                test_data["insolation"][1 if field.name=="insolation" else 0],
+                test_data["gravity"][1 if field.name=="gravity" else 0],
+                test_data["axial_tilt"][1 if field.name=="axial_tilt" else 0],
+                test_data["pressure_levels"][1 if field.name=="pressure_levels" else 0],
+                test_data["nlevels"][1 if field.name=="nlevels" else 0]
+            )
+            self.assertFalse(config1 == config2, f"Marked as equal when {field.name} is different")
+
+    def test_load_from_file(self):
+        test_config_file = PlanetConfigFile(
+            hours_in_day=1,
+            days_in_year=2,
+            resolution=3,
+            planet_radius=4000,
+            insolation=10,
+            gravity=9.2,
+            axial_tilt=20.0,
+            pressure_levels=[100,200,300]
+        )
+        expected_config = PlanetConfig(
+            day=3600,
+            year=7200,
+            resolution=3,
+            planet_radius=4000,
+            insolation=10,
+            gravity=9.2,
+            axial_tilt=20.0,
+            pressure_levels=np.array([10000,20000,30000]),
+            nlevels=3
+        )
+
+        result_config = PlanetConfig.load_from_file(test_config_file)
+
+        self.assertEqual(result_config, expected_config)
+

--- a/tests/model_tests/test_claude_config.py
+++ b/tests/model_tests/test_claude_config.py
@@ -474,3 +474,7 @@ class TestClaudeConfig(unittest.TestCase):
             save_config=expected_save_config,
             view_config=expected_view_config,
             coordinate_grid=expected_coordinate_grid)
+
+        result_claude_config = ClaudeConfig.load_from_file(test_claude_config_file)
+
+        self.assertEquals(result_claude_config, expected_claude_config)

--- a/tests/model_tests/test_claude_config.py
+++ b/tests/model_tests/test_claude_config.py
@@ -9,6 +9,7 @@ from model.claude_config import PlanetConfig, ClaudeConfig
 class TestPlanetConfig(unittest.TestCase):
 
     def test_equals_all_same(self):
+        # Arrange
         day=3600
         year=7200
         resolution=3
@@ -18,7 +19,7 @@ class TestPlanetConfig(unittest.TestCase):
         axial_tilt=20.0
         pressure_levels=np.array([10000,20000,30000])
         nlevels=3
-
+        # Act (set up 2 identical objects)
         config1 = PlanetConfig(
             day,
             year,
@@ -41,11 +42,10 @@ class TestPlanetConfig(unittest.TestCase):
             pressure_levels,
             nlevels
         )
-
-        self.assertTrue(config1 == config2)
+        # Assert
+        self.assertEquals(config1, config2)
     
     def test_equals_one_var_diffs(self):
-        
         test_data = {
             "day":[3600,2500],
             "year":[7200,3600],
@@ -70,6 +70,7 @@ class TestPlanetConfig(unittest.TestCase):
             test_data["nlevels"][0]
         )
 
+        # Loop around all the fields to set one different each time and check they come out as not equal
         for field in dataclasses.fields(PlanetConfig):
             config2 = PlanetConfig(
                 test_data["day"][1 if field.name=="day" else 0],
@@ -82,9 +83,10 @@ class TestPlanetConfig(unittest.TestCase):
                 test_data["pressure_levels"][1 if field.name=="pressure_levels" else 0],
                 test_data["nlevels"][1 if field.name=="nlevels" else 0]
             )
-            self.assertFalse(config1 == config2, f"Marked as equal when {field.name} is different")
+            self.assertNotEqual(config1, config2, f"Marked as equal when {field.name} is different")
 
     def test_load_from_file(self):
+        # Arrange
         test_config_file = PlanetConfigFile(
             hours_in_day=1,
             days_in_year=2,
@@ -106,8 +108,8 @@ class TestPlanetConfig(unittest.TestCase):
             pressure_levels=np.array([10000,20000,30000]),
             nlevels=3
         )
-
+        # Act
         result_config = PlanetConfig.load_from_file(test_config_file)
-
+        # Assert
         self.assertEqual(result_config, expected_config)
 

--- a/tests/model_tests/test_claude_config.py
+++ b/tests/model_tests/test_claude_config.py
@@ -1,24 +1,26 @@
 import dataclasses
-import unittest, os
-import numpy as np 
+import unittest
+import os
+import numpy as np
 
 from definitions import CONFIG_PATH
 from model.claude_config_file import PlanetConfigFile
 from model.claude_config import *
 
+
 class TestPlanetConfig(unittest.TestCase):
 
     def test_equals_all_same(self):
         # Arrange
-        day=3600
-        year=7200
-        resolution=3
-        planet_radius=4000
-        insolation=10
-        gravity=9.2
-        axial_tilt=20.0
-        pressure_levels=np.array([10000,20000,30000])
-        nlevels=3
+        day = 3600
+        year = 7200
+        resolution = 3
+        planet_radius = 4000
+        insolation = 10
+        gravity = 9.2
+        axial_tilt = 20.0
+        pressure_levels = np.array([10000, 20000, 30000])
+        nlevels = 3
         # Act (set up 2 identical objects)
         config1 = PlanetConfig(
             day,
@@ -44,18 +46,18 @@ class TestPlanetConfig(unittest.TestCase):
         )
         # Assert
         self.assertEqual(config1, config2)
-    
+
     def test_equals_one_var_diffs(self):
         test_data = {
-            "day":[3600,2500],
-            "year":[7200,3600],
-            "resolution":[3,4],
-            "planet_radius":[4000,5000],
-            "insolation":[10,8],
-            "gravity":[9.2,7.2],
-            "axial_tilt":[20.0,15.2],
-            "pressure_levels":[[10000,20000,30000],[1000, 2000, 3000]],
-            "nlevels":[3,4]
+            "day": [3600, 2500],
+            "year": [7200, 3600],
+            "resolution": [3, 4],
+            "planet_radius": [4000, 5000],
+            "insolation": [10, 8],
+            "gravity": [9.2, 7.2],
+            "axial_tilt": [20.0, 15.2],
+            "pressure_levels": [[10000, 20000, 30000], [1000, 2000, 3000]],
+            "nlevels": [3, 4]
         }
 
         config1 = PlanetConfig(
@@ -73,17 +75,23 @@ class TestPlanetConfig(unittest.TestCase):
         # Loop around all the fields to set one different each time and check they come out as not equal
         for field in dataclasses.fields(PlanetConfig):
             config2 = PlanetConfig(
-                test_data["day"][1 if field.name=="day" else 0],
-                test_data["year"][1 if field.name=="year" else 0],
-                test_data["resolution"][1 if field.name=="resolution" else 0],
-                test_data["planet_radius"][1 if field.name=="planet_radius" else 0],
-                test_data["insolation"][1 if field.name=="insolation" else 0],
-                test_data["gravity"][1 if field.name=="gravity" else 0],
-                test_data["axial_tilt"][1 if field.name=="axial_tilt" else 0],
-                np.array(test_data["pressure_levels"][1 if field.name=="pressure_levels" else 0]),
-                test_data["nlevels"][1 if field.name=="nlevels" else 0]
+                test_data["day"][1 if field.name == "day" else 0],
+                test_data["year"][1 if field.name == "year" else 0],
+                test_data["resolution"][1 if field.name ==
+                                        "resolution" else 0],
+                test_data["planet_radius"][1 if field.name ==
+                                           "planet_radius" else 0],
+                test_data["insolation"][1 if field.name ==
+                                        "insolation" else 0],
+                test_data["gravity"][1 if field.name == "gravity" else 0],
+                test_data["axial_tilt"][1 if field.name ==
+                                        "axial_tilt" else 0],
+                np.array(test_data["pressure_levels"]
+                         [1 if field.name == "pressure_levels" else 0]),
+                test_data["nlevels"][1 if field.name == "nlevels" else 0]
             )
-            self.assertNotEqual(config1, config2, f"Marked as equal when {field.name} is different")
+            self.assertNotEqual(
+                config1, config2, f"Marked as equal when {field.name} is different")
 
     def test_load_from_file(self):
         # Arrange
@@ -95,7 +103,7 @@ class TestPlanetConfig(unittest.TestCase):
             insolation=10,
             gravity=9.2,
             axial_tilt=20.0,
-            pressure_levels=[100,200,300]
+            pressure_levels=[100, 200, 300]
         )
         expected_config = PlanetConfig(
             day=3600,
@@ -105,7 +113,7 @@ class TestPlanetConfig(unittest.TestCase):
             insolation=10,
             gravity=9.2,
             axial_tilt=20.0,
-            pressure_levels=np.array([10000,20000,30000]),
+            pressure_levels=np.array([10000, 20000, 30000]),
             nlevels=3
         )
         # Act
@@ -113,16 +121,17 @@ class TestPlanetConfig(unittest.TestCase):
         # Assert
         self.assertEqual(result_config, expected_config)
 
+
 class TestSmoothingConfig(unittest.TestCase):
 
     def test_load_from_file(self):
         # Arrange
         smoothing = True
-        smoothing_parameter_t=2.2
-        smoothing_parameter_u=1.0
-        smoothing_parameter_v=0.3
-        smoothing_parameter_w=0.001
-        smoothing_parameter_add=3
+        smoothing_parameter_t = 2.2
+        smoothing_parameter_u = 1.0
+        smoothing_parameter_v = 0.3
+        smoothing_parameter_w = 0.001
+        smoothing_parameter_add = 3
 
         test_config_file = SmoothingConfigFile(
             smoothing=smoothing,
@@ -144,6 +153,7 @@ class TestSmoothingConfig(unittest.TestCase):
         result_config = SmoothingConfig.load_from_file(test_config_file)
         # Assert
         self.assertEqual(result_config, expected_config)
+
 
 class TestSaveConfig(unittest.TestCase):
 
@@ -171,20 +181,21 @@ class TestSaveConfig(unittest.TestCase):
         # Assert
         self.assertEqual(result_config, expected_config)
 
+
 class TestViewConfig(unittest.TestCase):
 
     def test_load_from_file(self):
         # Arrange
-        above=True
-        pole_string="n"
-        pole=PoleType(pole_string)
-        above_level=2
-        plot=True
-        diagnostic=True
-        level_plots=True
-        nplots=2
-        top=14
-        verbose=True
+        above = True
+        pole_string = "n"
+        pole = PoleType(pole_string)
+        above_level = 2
+        plot = True
+        diagnostic = True
+        level_plots = True
+        nplots = 2
+        top = 14
+        verbose = True
 
         test_config_file = ViewConfigFile(
             above=above,
@@ -212,6 +223,7 @@ class TestViewConfig(unittest.TestCase):
         result_config = ViewConfig.load_from_file(test_config_file)
         # Assert
         self.assertEqual(result_config, expected_config)
+
 
 class TestCoordinateGrid(unittest.TestCase):
 
@@ -279,17 +291,23 @@ class TestCoordinateGrid(unittest.TestCase):
         # Loop around all the fields to set one different each time and check they come out as not equal
         for field in dataclasses.fields(CoordinateGrid):
             config2 = CoordinateGrid(
-                np.array(test_data["lat"][1 if field.name=="lat" else 0]),
-                np.array(test_data["lon"][1 if field.name=="lon" else 0]),
-                np.array(test_data["nlat"][1 if field.name=="nlat" else 0]),
-                np.array(test_data["nlon"][1 if field.name=="nlon" else 0]),
-                np.array(test_data["lon_plot"][1 if field.name=="lon_plot" else 0]),
-                np.array(test_data["lat_plot"][1 if field.name=="lat_plot" else 0]),
-                np.array(test_data["heights_plot"][1 if field.name=="heights_plot" else 0]),
-                np.array(test_data["lat_z_plot"][1 if field.name=="lat_z_plot" else 0]),
-                test_data["temperature_world"][1 if field.name=="temperature_world" else 0]
+                np.array(test_data["lat"][1 if field.name == "lat" else 0]),
+                np.array(test_data["lon"][1 if field.name == "lon" else 0]),
+                np.array(test_data["nlat"][1 if field.name == "nlat" else 0]),
+                np.array(test_data["nlon"][1 if field.name == "nlon" else 0]),
+                np.array(test_data["lon_plot"]
+                         [1 if field.name == "lon_plot" else 0]),
+                np.array(test_data["lat_plot"]
+                         [1 if field.name == "lat_plot" else 0]),
+                np.array(test_data["heights_plot"]
+                         [1 if field.name == "heights_plot" else 0]),
+                np.array(test_data["lat_z_plot"]
+                         [1 if field.name == "lat_z_plot" else 0]),
+                test_data["temperature_world"][1 if field.name ==
+                                               "temperature_world" else 0]
             )
-            self.assertNotEqual(config1, config2, f"Marked as equal when {field.name} is different")
+            self.assertNotEqual(
+                config1, config2, f"Marked as equal when {field.name} is different")
 
     def test_load_from_file(self):
         resolution = 3
@@ -306,8 +324,6 @@ class TestCoordinateGrid(unittest.TestCase):
         heights_plot, lat_z_plot = np.meshgrid(lat, plotted_pressure_levels)
         temperature_world = np.zeros((nlat, nlon))
 
-        print(lat)
-
         expected_coordinate_grid = CoordinateGrid(
             lat,
             lon,
@@ -320,6 +336,141 @@ class TestCoordinateGrid(unittest.TestCase):
             temperature_world
         )
 
-        result_coordinate_grid = CoordinateGrid.load_from_file(resolution, top, pressure_levels)
+        result_coordinate_grid = CoordinateGrid.load_from_file(
+            resolution, top, pressure_levels)
 
         self.assertEqual(result_coordinate_grid, expected_coordinate_grid)
+
+
+class TestClaudeConfig(unittest.TestCase):
+
+    def test_load_from_file(self):
+        test_planet_config_file = PlanetConfigFile(
+            hours_in_day=1,
+            days_in_year=2,
+            resolution=3,
+            planet_radius=4000,
+            insolation=10,
+            gravity=9.2,
+            axial_tilt=20.0,
+            pressure_levels=[100, 200, 300]
+        )
+
+        expected_planet_config = PlanetConfig(
+            day=3600,
+            year=7200,
+            resolution=3,
+            planet_radius=4000,
+            insolation=10,
+            gravity=9.2,
+            axial_tilt=20.0,
+            pressure_levels=np.array([10000, 20000, 30000]),
+            nlevels=3
+        )
+
+        smoothing = True
+        smoothing_parameter_t = 2.2
+        smoothing_parameter_u = 1.0
+        smoothing_parameter_v = 0.3
+        smoothing_parameter_w = 0.001
+        smoothing_parameter_add = 3
+        test_smoothing_config_file = SmoothingConfigFile(
+            smoothing=smoothing,
+            smoothing_parameter_t=smoothing_parameter_t,
+            smoothing_parameter_u=smoothing_parameter_u,
+            smoothing_parameter_v=smoothing_parameter_v,
+            smoothing_parameter_w=smoothing_parameter_w,
+            smoothing_parameter_add=smoothing_parameter_add
+        )
+        expected_smoothing_config = SmoothingConfig(
+            smoothing=smoothing,
+            smoothing_parameter_t=smoothing_parameter_t,
+            smoothing_parameter_u=smoothing_parameter_u,
+            smoothing_parameter_v=smoothing_parameter_v,
+            smoothing_parameter_w=smoothing_parameter_w,
+            smoothing_parameter_add=smoothing_parameter_add
+        )
+
+        save = True
+        load = True
+        save_frequency = 3
+        plot_frequency = 10
+        test_save_config_file = SaveConfigFile(
+            save=save,
+            load=load,
+            save_frequency=save_frequency,
+            plot_frequency=plot_frequency
+        )
+        expected_save_config = SaveConfig(
+            save=save,
+            load=load,
+            save_frequency=save_frequency,
+            plot_frequency=plot_frequency
+        )
+
+        above = True
+        pole_string = "n"
+        pole = PoleType(pole_string)
+        above_level = 2
+        plot = True
+        diagnostic = True
+        level_plots = True
+        nplots = 2
+        top = 14
+        verbose = True
+        test_view_config_file = ViewConfigFile(
+            above=above,
+            pole=pole_string,
+            above_level=above_level,
+            plot=plot,
+            diagnostic=diagnostic,
+            level_plots=level_plots,
+            nplots=nplots,
+            top=top,
+            verbose=verbose
+        )
+        expected_view_config = ViewConfig(
+            above=above,
+            pole=pole,
+            above_level=above_level,
+            plot=plot,
+            diagnostic=diagnostic,
+            level_plots=level_plots,
+            nplots=nplots,
+            top=top,
+            verbose=verbose
+        )
+
+        lat = np.arange(-90, 91, expected_planet_config.resolution)
+        lon = np.arange(0, 360, expected_planet_config.resolution)
+        nlat = len(lat)
+        nlon = len(lon)
+        lon_plot, lat_plot = np.meshgrid(lon, lat)
+        heights_plot, lat_z_plot = np.meshgrid(
+            lat, expected_planet_config.pressure_levels[:expected_view_config.top]/100)
+        temperature_world = np.zeros((nlat, nlon))
+        expected_coordinate_grid = CoordinateGrid(
+            lat,
+            lon,
+            nlat,
+            nlon,
+            lon_plot,
+            lat_plot,
+            heights_plot,
+            lat_z_plot,
+            temperature_world
+        )
+
+        test_claude_config_file = ClaudeConfigFile(
+            planet_config=test_planet_config_file,
+            smoothing_config=test_smoothing_config_file,
+            save_config=test_save_config_file,
+            view_config=test_view_config_file
+        )
+
+        expected_claude_config = ClaudeConfig(
+            planet_config=expected_planet_config,
+            smoothing_config=expected_smoothing_config,
+            save_config=expected_save_config,
+            view_config=expected_view_config,
+            coordinate_grid=expected_coordinate_grid)

--- a/tests/model_tests/test_claude_config.py
+++ b/tests/model_tests/test_claude_config.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from definitions import CONFIG_PATH
 from model.claude_config_file import PlanetConfigFile
-from model.claude_config import PlanetConfig, ClaudeConfig
+from model.claude_config import *
 
 class TestPlanetConfig(unittest.TestCase):
 
@@ -28,7 +28,7 @@ class TestPlanetConfig(unittest.TestCase):
             insolation,
             gravity,
             axial_tilt,
-            pressure_levels,
+            np.array(pressure_levels),
             nlevels
         )
         config2 = PlanetConfig(
@@ -39,11 +39,11 @@ class TestPlanetConfig(unittest.TestCase):
             insolation,
             gravity,
             axial_tilt,
-            pressure_levels,
+            np.array(pressure_levels),
             nlevels
         )
         # Assert
-        self.assertEquals(config1, config2)
+        self.assertEqual(config1, config2)
     
     def test_equals_one_var_diffs(self):
         test_data = {
@@ -54,7 +54,7 @@ class TestPlanetConfig(unittest.TestCase):
             "insolation":[10,8],
             "gravity":[9.2,7.2],
             "axial_tilt":[20.0,15.2],
-            "pressure_levels":[np.array([10000,20000,30000]),np.array([1000, 2000, 3000])],
+            "pressure_levels":[[10000,20000,30000],[1000, 2000, 3000]],
             "nlevels":[3,4]
         }
 
@@ -66,7 +66,7 @@ class TestPlanetConfig(unittest.TestCase):
             test_data["insolation"][0],
             test_data["gravity"][0],
             test_data["axial_tilt"][0],
-            test_data["pressure_levels"][0],
+            np.array(test_data["pressure_levels"][0]),
             test_data["nlevels"][0]
         )
 
@@ -80,7 +80,7 @@ class TestPlanetConfig(unittest.TestCase):
                 test_data["insolation"][1 if field.name=="insolation" else 0],
                 test_data["gravity"][1 if field.name=="gravity" else 0],
                 test_data["axial_tilt"][1 if field.name=="axial_tilt" else 0],
-                test_data["pressure_levels"][1 if field.name=="pressure_levels" else 0],
+                np.array(test_data["pressure_levels"][1 if field.name=="pressure_levels" else 0]),
                 test_data["nlevels"][1 if field.name=="nlevels" else 0]
             )
             self.assertNotEqual(config1, config2, f"Marked as equal when {field.name} is different")
@@ -113,3 +113,213 @@ class TestPlanetConfig(unittest.TestCase):
         # Assert
         self.assertEqual(result_config, expected_config)
 
+class TestSmoothingConfig(unittest.TestCase):
+
+    def test_load_from_file(self):
+        # Arrange
+        smoothing = True
+        smoothing_parameter_t=2.2
+        smoothing_parameter_u=1.0
+        smoothing_parameter_v=0.3
+        smoothing_parameter_w=0.001
+        smoothing_parameter_add=3
+
+        test_config_file = SmoothingConfigFile(
+            smoothing=smoothing,
+            smoothing_parameter_t=smoothing_parameter_t,
+            smoothing_parameter_u=smoothing_parameter_u,
+            smoothing_parameter_v=smoothing_parameter_v,
+            smoothing_parameter_w=smoothing_parameter_w,
+            smoothing_parameter_add=smoothing_parameter_add
+        )
+        expected_config = SmoothingConfig(
+            smoothing=smoothing,
+            smoothing_parameter_t=smoothing_parameter_t,
+            smoothing_parameter_u=smoothing_parameter_u,
+            smoothing_parameter_v=smoothing_parameter_v,
+            smoothing_parameter_w=smoothing_parameter_w,
+            smoothing_parameter_add=smoothing_parameter_add
+        )
+        # Act
+        result_config = SmoothingConfig.load_from_file(test_config_file)
+        # Assert
+        self.assertEqual(result_config, expected_config)
+
+class TestSaveConfig(unittest.TestCase):
+
+    def test_load_from_file(self):
+        # Arrange
+        save = True
+        load = True
+        save_frequency = 3
+        plot_frequency = 10
+
+        test_config_file = SaveConfigFile(
+            save=save,
+            load=load,
+            save_frequency=save_frequency,
+            plot_frequency=plot_frequency
+        )
+        expected_config = SaveConfig(
+            save=save,
+            load=load,
+            save_frequency=save_frequency,
+            plot_frequency=plot_frequency
+        )
+        # Act
+        result_config = SaveConfig.load_from_file(test_config_file)
+        # Assert
+        self.assertEqual(result_config, expected_config)
+
+class TestViewConfig(unittest.TestCase):
+
+    def test_load_from_file(self):
+        # Arrange
+        above=True
+        pole_string="n"
+        pole=PoleType(pole_string)
+        above_level=2
+        plot=True
+        diagnostic=True
+        level_plots=True
+        nplots=2
+        top=14
+        verbose=True
+
+        test_config_file = ViewConfigFile(
+            above=above,
+            pole=pole_string,
+            above_level=above_level,
+            plot=plot,
+            diagnostic=diagnostic,
+            level_plots=level_plots,
+            nplots=nplots,
+            top=top,
+            verbose=verbose
+        )
+        expected_config = ViewConfig(
+            above=above,
+            pole=pole,
+            above_level=above_level,
+            plot=plot,
+            diagnostic=diagnostic,
+            level_plots=level_plots,
+            nplots=nplots,
+            top=top,
+            verbose=verbose
+        )
+        # Act
+        result_config = ViewConfig.load_from_file(test_config_file)
+        # Assert
+        self.assertEqual(result_config, expected_config)
+
+class TestCoordinateGrid(unittest.TestCase):
+
+    def test_equals_all_same(self):
+        lat = np.array([1, 2, 3])
+        lon = np.array([4, 5, 6])
+        nlat = 4
+        nlon = 5
+        lon_plot = np.array([7, 8, 9])
+        lat_plot = np.array([10, 11, 12])
+        heights_plot = np.array([13, 14, 15])
+        lat_z_plot = np.array([16, 17, 18])
+        temperature_world = np.zeros((nlat, nlon))
+
+        grid1 = CoordinateGrid(
+            lat,
+            lon,
+            nlat,
+            nlon,
+            lon_plot,
+            lat_plot,
+            heights_plot,
+            lat_z_plot,
+            temperature_world
+        )
+        grid2 = CoordinateGrid(
+            lat,
+            lon,
+            nlat,
+            nlon,
+            lon_plot,
+            lat_plot,
+            heights_plot,
+            lat_z_plot,
+            temperature_world
+        )
+
+        self.assertEqual(grid1, grid2)
+
+    def test_equals_one_var_diffs(self):
+        test_data = {
+            "lat": [[1, 2, 3], [4, 5, 6]],
+            "lon": [[4, 5, 6], [7, 8, 9]],
+            "nlat": [4, 5],
+            "nlon": [5, 6],
+            "lon_plot": [[7, 8, 9], [10, 11, 12]],
+            "lat_plot": [[10, 11, 12], [13, 14, 15]],
+            "heights_plot": [[13, 14, 15], [16, 17, 18]],
+            "lat_z_plot": [[16, 17, 18], [17, 18, 19]],
+            "temperature_world": [np.zeros((4, 5)), np.zeros((6, 7))]
+        }
+
+        config1 = CoordinateGrid(
+            np.array(test_data["lat"][0]),
+            np.array(test_data["lon"][0]),
+            np.array(test_data["nlat"][0]),
+            np.array(test_data["nlon"][0]),
+            np.array(test_data["lon_plot"][0]),
+            np.array(test_data["lat_plot"][0]),
+            np.array(test_data["heights_plot"][0]),
+            np.array(test_data["lat_z_plot"][0]),
+            test_data["temperature_world"][0]
+        )
+
+        # Loop around all the fields to set one different each time and check they come out as not equal
+        for field in dataclasses.fields(CoordinateGrid):
+            config2 = CoordinateGrid(
+                np.array(test_data["lat"][1 if field.name=="lat" else 0]),
+                np.array(test_data["lon"][1 if field.name=="lon" else 0]),
+                np.array(test_data["nlat"][1 if field.name=="nlat" else 0]),
+                np.array(test_data["nlon"][1 if field.name=="nlon" else 0]),
+                np.array(test_data["lon_plot"][1 if field.name=="lon_plot" else 0]),
+                np.array(test_data["lat_plot"][1 if field.name=="lat_plot" else 0]),
+                np.array(test_data["heights_plot"][1 if field.name=="heights_plot" else 0]),
+                np.array(test_data["lat_z_plot"][1 if field.name=="lat_z_plot" else 0]),
+                test_data["temperature_world"][1 if field.name=="temperature_world" else 0]
+            )
+            self.assertNotEqual(config1, config2, f"Marked as equal when {field.name} is different")
+
+    def test_load_from_file(self):
+        resolution = 3
+        top = 4
+        pressure_levels = np.array([100, 200, 300, 400, 500])
+
+        plotted_pressure_levels = np.array([1, 2, 3, 4])
+
+        lat = np.arange(-90, 91, resolution)
+        lon = np.arange(0, 360, resolution)
+        nlat = len(lat)
+        nlon = len(lon)
+        lon_plot, lat_plot = np.meshgrid(lon, lat)
+        heights_plot, lat_z_plot = np.meshgrid(lat, plotted_pressure_levels)
+        temperature_world = np.zeros((nlat, nlon))
+
+        print(lat)
+
+        expected_coordinate_grid = CoordinateGrid(
+            lat,
+            lon,
+            nlat,
+            nlon,
+            lon_plot,
+            lat_plot,
+            heights_plot,
+            lat_z_plot,
+            temperature_world
+        )
+
+        result_coordinate_grid = CoordinateGrid.load_from_file(resolution, top, pressure_levels)
+
+        self.assertEqual(result_coordinate_grid, expected_coordinate_grid)

--- a/tests/model_tests/test_claude_config.py
+++ b/tests/model_tests/test_claude_config.py
@@ -6,9 +6,4 @@ from model.claude_config import ClaudeConfig
 class TestClaudeConfig(unittest.TestCase):
 
     def test_yaml_load(self):
-        # Arrange (Set Up Test)
-        defaultClaudeConfigData = open(os.path.join(CONFIG_PATH, "DefaultClaudeConfig.yaml"))
-        # Act (Perform Action to be Tested)
-        resultClaudeConfig = ClaudeConfig.load_from_yaml(defaultClaudeConfigData)
-        # Assert (Check our results)
-        print(resultClaudeConfig)
+        pass

--- a/tests/model_tests/test_claude_config.py
+++ b/tests/model_tests/test_claude_config.py
@@ -1,7 +1,7 @@
 import unittest, os
 from definitions import CONFIG_PATH
 
-from model.config import ClaudeConfig
+from model.claude_config import ClaudeConfig
 
 class TestClaudeConfig(unittest.TestCase):
 

--- a/tests/model_tests/test_claude_config.py
+++ b/tests/model_tests/test_claude_config.py
@@ -1,6 +1,5 @@
-import dataclasses
-import unittest
-import os
+import dataclasses, unittest
+
 import numpy as np
 
 from definitions import CONFIG_PATH

--- a/tests/model_tests/test_claude_config_file.py
+++ b/tests/model_tests/test_claude_config_file.py
@@ -1,6 +1,4 @@
-import unittest
-import os
-import yaml
+import unittest, os, yaml
 
 from yaml import Loader
 from definitions import CONFIG_PATH

--- a/tests/model_tests/test_claude_config_file.py
+++ b/tests/model_tests/test_claude_config_file.py
@@ -1,4 +1,6 @@
-import unittest, os, yaml
+import unittest
+import os
+import yaml
 
 from yaml import Loader
 from definitions import CONFIG_PATH
@@ -97,6 +99,7 @@ class TestViewConfigFile(unittest.TestCase):
 
         # Assert (Check our results)
         self.assertEqual(expected_view_config, result_view_config)
+
 
 class TestClaudeConfigFile(unittest.TestCase):
     def test_yaml_mapping(self):

--- a/tests/model_tests/test_claude_config_file.py
+++ b/tests/model_tests/test_claude_config_file.py
@@ -1,0 +1,37 @@
+import unittest, os, yaml
+
+from yaml import Loader
+from definitions import CONFIG_PATH
+from model.claude_config_file import PlanetConfigFile
+
+class TestPlanetConfigFile(unittest.TestCase):
+
+    def test_yaml_mapping(self):
+        #Arrange (set up test)
+        test_planet_config = open(os.path.join(os.path.dirname(__file__), "test_files", "TestPlanetConfig.yaml"))
+
+        expected_planet_config = PlanetConfigFile(
+            hours_in_day = 24,
+            days_in_year = 365,
+            resolution = 3,
+            planet_radius = 6.4E6,
+            insolation = 1370,
+            gravity = 9.81,
+            axial_tilt = 23.5,
+            pressure_levels = [1000,950,900,800]
+        )
+
+        # Act (Perform Action to be Tested)
+        result_planet_config = yaml.load(test_planet_config, Loader=Loader)
+
+        # Assert (Check our results)
+        self.assertEqual(result_planet_config.hours_in_day, expected_planet_config.hours_in_day)
+        self.assertEqual(result_planet_config.days_in_year, expected_planet_config.days_in_year)
+        self.assertEqual(result_planet_config.resolution, expected_planet_config.resolution)
+        self.assertEqual(result_planet_config.insolation, expected_planet_config.insolation)
+        self.assertEqual(result_planet_config.gravity, expected_planet_config.gravity)
+        self.assertEqual(result_planet_config.axial_tilt, expected_planet_config.axial_tilt)
+        self.assertEqual(result_planet_config.pressure_levels, expected_planet_config.pressure_levels)
+
+
+

--- a/tests/model_tests/test_claude_config_file.py
+++ b/tests/model_tests/test_claude_config_file.py
@@ -1,23 +1,27 @@
-import unittest, os, yaml
+import unittest
+import os
+import yaml
 
 from yaml import Loader
 from definitions import CONFIG_PATH
-from model.claude_config_file import PlanetConfigFile
+from model.claude_config_file import PlanetConfigFile, SmoothingConfigFile, SaveConfigFile, ViewConfigFile, ClaudeConfigFile
+
 
 class TestPlanetConfigFile(unittest.TestCase):
     def test_yaml_mapping(self):
-        #Arrange (set up test)
-        test_planet_config = open(os.path.join(os.path.dirname(__file__), "test_files", "TestPlanetConfig.yaml"))
+        # Arrange (set up test)
+        test_planet_config = open(os.path.join(os.path.dirname(
+            __file__), "test_files", "TestPlanetConfig.yaml"))
 
         expected_planet_config = PlanetConfigFile(
-            hours_in_day = 24,
-            days_in_year = 365,
-            resolution = 3,
-            planet_radius = 6.4E6,
-            insolation = 1370,
-            gravity = 9.81,
-            axial_tilt = 23.5,
-            pressure_levels = [1000,950,900,800]
+            hours_in_day=24,
+            days_in_year=365,
+            resolution=3,
+            planet_radius=6.4E6,
+            insolation=1370,
+            gravity=9.81,
+            axial_tilt=23.5,
+            pressure_levels=[1000, 950, 900, 800]
         )
 
         # Act (Perform Action to be Tested)
@@ -25,3 +29,128 @@ class TestPlanetConfigFile(unittest.TestCase):
 
         # Assert (Check our results)
         self.assertEqual(result_planet_config, expected_planet_config)
+
+
+class TestSmoothingConfigFile(unittest.TestCase):
+    def test_yaml_mapping(self):
+        # Arrange (set up test)
+        test_smoothing_config = open(os.path.join(os.path.dirname(
+            __file__), "test_files", "TestSmoothingConfig.yaml"))
+
+        expected_smoothing_config = SmoothingConfigFile(
+            smoothing=False,
+            smoothing_parameter_t=1.0,
+            smoothing_parameter_u=0.9,
+            smoothing_parameter_v=0.9,
+            smoothing_parameter_w=0.3,
+            smoothing_parameter_add=0.3
+        )
+
+        # Act (Perform Action to be Tested)
+        result_smoothing_config = yaml.load(
+            test_smoothing_config, Loader=Loader)
+
+        # Assert (Check our results)
+        self.assertEqual(result_smoothing_config, expected_smoothing_config)
+
+
+class TestSaveConfigFile(unittest.TestCase):
+    def test_yaml_mapping(self):
+        # Arrange (set up test)
+        test_save_config = open(os.path.join(os.path.dirname(
+            __file__), "test_files", "TestSaveConfig.yaml"))
+
+        expected_save_config = SaveConfigFile(
+            save=True,
+            load=True,
+            save_frequency=100,
+            plot_frequency=5
+        )
+
+        # Act (Perform Action to be Tested)
+        result_save_config = yaml.load(
+            test_save_config, Loader=Loader)
+
+        # Assert (Check our results)
+        self.assertEqual(expected_save_config, result_save_config)
+
+
+class TestViewConfigFile(unittest.TestCase):
+    def test_yaml_mapping(self):
+        # Arrange (set up test)
+        test_view_config = open(os.path.join(os.path.dirname(
+            __file__), "test_files", "TestViewConfig.yaml"))
+
+        expected_view_config = ViewConfigFile(
+            above=False,
+            pole='n',
+            above_level=16,
+            plot=True,
+            diagnostic=False,
+            level_plots=False,
+            nplots=3,
+            top=17,
+            verbose=False
+        )
+
+        # Act (Perform Action to be Tested)
+        result_view_config = yaml.load(
+            test_view_config, Loader=Loader)
+
+        # Assert (Check our results)
+        self.assertEqual(expected_view_config, result_view_config)
+
+class TestClaudeConfigFile(unittest.TestCase):
+    def test_yaml_mapping(self):
+        # Arrange (set up test)
+        test_claude_config = open(os.path.join(os.path.dirname(
+            __file__), "test_files", "TestClaudeConfig.yaml"))
+
+        expected_planet_config = PlanetConfigFile(
+            hours_in_day=24,
+            days_in_year=365,
+            resolution=3,
+            planet_radius=6.4E6,
+            insolation=1370,
+            gravity=9.81,
+            axial_tilt=23.5,
+            pressure_levels=[1000, 950, 900, 800]
+        )
+        expected_smoothing_config = SmoothingConfigFile(
+            smoothing=False,
+            smoothing_parameter_t=1.0,
+            smoothing_parameter_u=0.9,
+            smoothing_parameter_v=0.9,
+            smoothing_parameter_w=0.3,
+            smoothing_parameter_add=0.3
+        )
+        expected_save_config = SaveConfigFile(
+            save=True,
+            load=True,
+            save_frequency=100,
+            plot_frequency=5
+        )
+        expected_view_config = ViewConfigFile(
+            above=False,
+            pole='n',
+            above_level=16,
+            plot=True,
+            diagnostic=False,
+            level_plots=False,
+            nplots=3,
+            top=17,
+            verbose=False
+        )
+        expected_claude_config = ClaudeConfigFile(
+            planet_config=expected_planet_config,
+            smoothing_config=expected_smoothing_config,
+            save_config=expected_save_config,
+            view_config=expected_view_config
+        )
+
+        # Act (Perform Action to be Tested)
+        result_claude_config = yaml.load(
+            test_claude_config, Loader=Loader)
+
+        # Assert (Check our results)
+        self.assertEqual(expected_claude_config, result_claude_config)

--- a/tests/model_tests/test_claude_config_file.py
+++ b/tests/model_tests/test_claude_config_file.py
@@ -5,7 +5,6 @@ from definitions import CONFIG_PATH
 from model.claude_config_file import PlanetConfigFile
 
 class TestPlanetConfigFile(unittest.TestCase):
-
     def test_yaml_mapping(self):
         #Arrange (set up test)
         test_planet_config = open(os.path.join(os.path.dirname(__file__), "test_files", "TestPlanetConfig.yaml"))
@@ -25,13 +24,4 @@ class TestPlanetConfigFile(unittest.TestCase):
         result_planet_config = yaml.load(test_planet_config, Loader=Loader)
 
         # Assert (Check our results)
-        self.assertEqual(result_planet_config.hours_in_day, expected_planet_config.hours_in_day)
-        self.assertEqual(result_planet_config.days_in_year, expected_planet_config.days_in_year)
-        self.assertEqual(result_planet_config.resolution, expected_planet_config.resolution)
-        self.assertEqual(result_planet_config.insolation, expected_planet_config.insolation)
-        self.assertEqual(result_planet_config.gravity, expected_planet_config.gravity)
-        self.assertEqual(result_planet_config.axial_tilt, expected_planet_config.axial_tilt)
-        self.assertEqual(result_planet_config.pressure_levels, expected_planet_config.pressure_levels)
-
-
-
+        self.assertEqual(result_planet_config, expected_planet_config)

--- a/tests/model_tests/test_config.py
+++ b/tests/model_tests/test_config.py
@@ -1,0 +1,14 @@
+import unittest, os
+from definitions import CONFIG_PATH
+
+from model.config import ClaudeConfig
+
+class TestClaudeConfig(unittest.TestCase):
+
+    def test_yaml_load(self):
+        # Arrange (Set Up Test)
+        defaultClaudeConfigData = open(os.path.join(CONFIG_PATH, "DefaultClaudeConfig.yaml"))
+        # Act (Perform Action to be Tested)
+        resultClaudeConfig = ClaudeConfig.load_from_yaml(defaultClaudeConfigData)
+        # Assert (Check our results)
+        print(resultClaudeConfig)

--- a/tests/model_tests/test_files/TestClaudeConfig.yaml
+++ b/tests/model_tests/test_files/TestClaudeConfig.yaml
@@ -1,4 +1,4 @@
---- !ClaudeConfig # These are Type Tags to guide config loading and should always be left in
+--- !ClaudeConfig
 planet_config: !PlanetConfig
     hours_in_day: 24                  # define length of day (used for calculating Coriolis as well) (s)
     days_in_year: 365                 # define how many days in a year

--- a/tests/model_tests/test_files/TestPlanetConfig.yaml
+++ b/tests/model_tests/test_files/TestPlanetConfig.yaml
@@ -1,0 +1,10 @@
+--- !PlanetConfig
+"hours_in_day": 24
+"days_in_year": 365
+"resolution": 3
+"planet_radius": 6.4E6
+"insolation": 1370
+"gravity": 9.81
+"axial_tilt": 23.5
+"pressure_levels": [1000,950,900,800]
+...

--- a/tests/model_tests/test_files/TestPlanetConfig.yaml
+++ b/tests/model_tests/test_files/TestPlanetConfig.yaml
@@ -2,7 +2,7 @@
 "hours_in_day": 24
 "days_in_year": 365
 "resolution": 3
-"planet_radius": 6.4E6
+"planet_radius": 6.4E+6
 "insolation": 1370
 "gravity": 9.81
 "axial_tilt": 23.5

--- a/tests/model_tests/test_files/TestSaveConfig.yaml
+++ b/tests/model_tests/test_files/TestSaveConfig.yaml
@@ -1,0 +1,6 @@
+--- !SaveConfig
+save: True
+load: True
+save_frequency: 100
+plot_frequency: 5
+...

--- a/tests/model_tests/test_files/TestSmoothingConfig.yaml
+++ b/tests/model_tests/test_files/TestSmoothingConfig.yaml
@@ -1,0 +1,8 @@
+--- !SmoothingConfig
+"smoothing": False
+"smoothing_parameter_t": 1.0
+"smoothing_parameter_u": 0.9
+"smoothing_parameter_v": 0.9
+"smoothing_parameter_w": 0.3
+"smoothing_parameter_add": 0.3
+...

--- a/tests/model_tests/test_files/TestViewConfig.yaml
+++ b/tests/model_tests/test_files/TestViewConfig.yaml
@@ -1,0 +1,11 @@
+--- !ViewConfig
+above: False
+pole: 'n'
+above_level: 16
+plot: True
+diagnostic: False
+level_plots: False
+nplots: 3
+top: 17
+verbose: False
+...

--- a/toy_model.py
+++ b/toy_model.py
@@ -2,12 +2,24 @@
 
 import numpy as np 
 import matplotlib.pyplot as plt
-import time, sys, pickle
+import time, sys, pickle, os, yaml
 import claude_low_level_library as low_level
 import claude_top_level_library as top_level
+
+from yaml import Loader
+from definitions import CONFIG_PATH
+from model.claude_config_file import ClaudeConfigFile, PlanetConfigFile, SaveConfigFile, ViewConfigFile
+from model.claude_config import ClaudeConfig
 # from twitch import prime_sub
 
 ######## CONTROL ########
+
+DEFAULT_CONFIG_FILE = "DefaultClaudeConfig.yaml"
+
+## Load Configuration
+config_file = open(os.path.join(CONFIG_PATH, DEFAULT_CONFIG_FILE))
+claude_config_file = yaml.load(config_file, Loader=Loader)
+claude_config = ClaudeConfig.load_from_file(claude_config_file=claude_config_file)
 
 day = 60*60*24						# define length of day (used for calculating Coriolis as well) (s)
 resolution = 3						# how many degrees between latitude and longitude gridpoints

--- a/toy_model.py
+++ b/toy_model.py
@@ -10,6 +10,7 @@ from yaml import Loader
 from definitions import CONFIG_PATH
 from model.claude_config_file import ClaudeConfigFile, PlanetConfigFile, SaveConfigFile, ViewConfigFile
 from model.claude_config import ClaudeConfig
+from model.pole_enum import PoleType
 # from twitch import prime_sub
 
 ######## CONTROL ########
@@ -21,75 +22,32 @@ config_file = open(os.path.join(CONFIG_PATH, DEFAULT_CONFIG_FILE))
 claude_config_file = yaml.load(config_file, Loader=Loader)
 claude_config = ClaudeConfig.load_from_file(claude_config_file=claude_config_file)
 
-day = 60*60*24						# define length of day (used for calculating Coriolis as well) (s)
-resolution = 3						# how many degrees between latitude and longitude gridpoints
-planet_radius = 6.4E6				# define the planet's radius (m)
-insolation = 1370					# TOA radiation from star (W m^-2)
-gravity = 9.81 						# define surface gravity for planet (m s^-2)
-axial_tilt = 23.5					# tilt of rotational axis w.r.t. solar plane
-year = 365*day						# length of year (s)
-
-pressure_levels = np.array([1000,950,900,800,700,600,500,400,350,300,250,200,150,100,75,50,25,10,5,2,1])
-pressure_levels *= 100
-nlevels = len(pressure_levels)
-
+###
+planet_config = claude_config.planet_config
 dt_spinup = 60*17.2					# timestep for initial period where the model only calculates radiative effects
 dt_main = 60*9.2					# timestep for the main sequence where the model calculates velocities/advection
-spinup_length = 0*day 				# how long the model should only calculate radiative effects
+spinup_length = 0*planet_config.day 				# how long the model should only calculate radiative effects
+###
+smoothing_config = claude_config.smoothing_config
+###
+save_config = claude_config.save_config
 
 ###
-
-smoothing = False					# you probably won't need this, but there is the option to smooth out fields using FFTs (NB this slows down computation considerably and can introduce nonphysical errors)
-smoothing_parameter_t = 1.0			
-smoothing_parameter_u = 0.9			
-smoothing_parameter_v = 0.9			
-smoothing_parameter_w = 0.3			
-smoothing_parameter_add = 0.3		
-
-###
-
-save = True 						# save current state to file?
-load = True  						# load initial state from file?
-
-save_frequency = 100				# write to file after this many timesteps have passed
-plot_frequency = 5					# how many timesteps between plots (set this low if you want realtime plots, set this high to improve performance)
-
-###
-
-above = False 						# display top down view of a pole? showing polar plane data and regular gridded data
-pole = 'n'							# which pole to display - 'n' for north, 's' for south
-above_level = 16					# which vertical level to display over the pole
-
-plot = True     					# display plots of output?
-diagnostic = False 					# display raw fields for diagnostic purposes
-level_plots = False					# display plots of output on vertical levels?
-nplots = 3							# how many levels you want to see plots of (evenly distributed through column)
-top = 17							# top pressure level to display (i.e. trim off sponge layer)
-
-verbose = False						# print times taken to calculate specific processes each timestep
-
+view_config = claude_config.view_config
 ###
 
 pole_lower_latitude_limit = -75		# how far north polar plane data is calculated from the south pole (do not set this beyond 45!) [mirrored to north pole as well]
 pole_higher_latitude_limit = -85	# how far south regular gridded data is calculated (do not set beyond about 80) [also mirrored to north pole]
 
 ###
-
-# define coordinate arrays
-lat = np.arange(-90,91,resolution)
-lon = np.arange(0,360,resolution)
-nlat = len(lat)
-nlon = len(lon)
-lon_plot, lat_plot = np.meshgrid(lon, lat)
-heights_plot, lat_z_plot = np.meshgrid(lat,pressure_levels[:top]/100)
-temperature_world = np.zeros((nlat,nlon))
+coordinate_grid = claude_config.coordinate_grid
 
 ##########################
 
-if not load:
+if not save_config.load:
 	# initialise arrays for various physical fields
-	temperature_world += 290
-	potential_temperature = np.zeros((nlat,nlon,nlevels))
+	coordinate_grid.temperature_world += 290
+	potential_temperature = np.zeros((coordinate_grid.nlat,coordinate_grid.nlon,planet_config.nlevels))
 	u = np.zeros_like(potential_temperature)
 	v = np.zeros_like(potential_temperature)
 	w = np.zeros_like(potential_temperature)
@@ -106,57 +64,57 @@ if not load:
 	f.close()
 
 	# density_profile = np.interp(x=heights/1E3,xp=standard_height,fp=standard_density)
-	temp_profile = np.interp(x=pressure_levels[::-1],xp=standard_pressure[::-1],fp=standard_temp[::-1])[::-1]
-	for k in range(nlevels):
+	temp_profile = np.interp(x=planet_config.pressure_levels[::-1],xp=standard_pressure[::-1],fp=standard_temp[::-1])[::-1]
+	for k in range(planet_config.nlevels):
 		potential_temperature[:,:,k] = temp_profile[k]
 
-	potential_temperature = low_level.t_to_theta(potential_temperature,pressure_levels)
+	potential_temperature = low_level.t_to_theta(potential_temperature,planet_config.pressure_levels)
 	geopotential = np.zeros_like(potential_temperature)
 
 initial_setup = True
 if initial_setup:
-	sigma = np.zeros_like(pressure_levels)
+	sigma = np.zeros_like(planet_config.pressure_levels)
 	kappa = 287/1000
 	for i in range(len(sigma)):
-		sigma[i] = 1E3*(pressure_levels[i]/pressure_levels[0])**kappa
+		sigma[i] = 1E3*(planet_config.pressure_levels[i]/planet_config.pressure_levels[0])**kappa
 
-	heat_capacity_earth = np.zeros_like(temperature_world) + 1E6
+	heat_capacity_earth = np.zeros_like(coordinate_grid.temperature_world) + 1E6
 
 	# heat_capacity_earth[15:36,30:60] = 1E7
 	# heat_capacity_earth[30:40,80:90] = 1E7
 
 	albedo_variance = 0.001
-	albedo = np.random.uniform(-albedo_variance,albedo_variance, (nlat, nlon)) + 0.2
-	albedo = np.zeros((nlat, nlon)) + 0.2
+	albedo = np.random.uniform(-albedo_variance,albedo_variance, (coordinate_grid.nlat, coordinate_grid.nlon)) + 0.2
+	albedo = np.zeros((coordinate_grid.nlat, coordinate_grid.nlon)) + 0.2
 
 	specific_gas = 287
 	thermal_diffusivity_roc = 1.5E-6
 
 	# define planet size and various geometric constants
-	circumference = 2*np.pi*planet_radius
-	circle = np.pi*planet_radius**2
-	sphere = 4*np.pi*planet_radius**2
+	circumference = 2*np.pi*planet_config.planet_radius
+	circle = np.pi*planet_config.planet_radius**2
+	sphere = 4*np.pi*planet_config.planet_radius**2
 
 	# define how far apart the gridpoints are: note that we use central difference derivatives, and so these distances are actually twice the distance between gridboxes
-	dy = circumference/nlat
-	dx = np.zeros(nlat)
-	coriolis = np.zeros(nlat)	# also define the coriolis parameter here
-	angular_speed = 2*np.pi/day
-	for i in range(nlat):
-		dx[i] = dy*np.cos(lat[i]*np.pi/180)
-		coriolis[i] = angular_speed*np.sin(lat[i]*np.pi/180)
+	dy = circumference/coordinate_grid.nlat
+	dx = np.zeros(coordinate_grid.nlat)
+	coriolis = np.zeros(coordinate_grid.nlat)	# also define the coriolis parameter here
+	angular_speed = 2*np.pi/planet_config.day
+	for i in range(coordinate_grid.nlat):
+		dx[i] = dy*np.cos(coordinate_grid.lat[i]*np.pi/180)
+		coriolis[i] = angular_speed*np.sin(coordinate_grid.lat[i]*np.pi/180)
 
 setup_grids = True
 if setup_grids:
 
 	grid_pad = 2
 	
-	pole_low_index_S = np.where(lat > pole_lower_latitude_limit)[0][0]
-	pole_high_index_S = np.where(lat > pole_higher_latitude_limit)[0][0]
+	pole_low_index_S = np.where(coordinate_grid.lat > pole_lower_latitude_limit)[0][0]
+	pole_high_index_S = np.where(coordinate_grid.lat > pole_higher_latitude_limit)[0][0]
 
 	# initialise grid
 	polar_grid_resolution = dx[pole_low_index_S]
-	size_of_grid = planet_radius*np.cos(lat[pole_low_index_S+grid_pad]*np.pi/180.0)
+	size_of_grid = planet_config.planet_radius*np.cos(coordinate_grid.lat[pole_low_index_S+grid_pad]*np.pi/180.0)
 
 	### south pole ###
 	grid_x_values_S = np.arange(-size_of_grid,size_of_grid,polar_grid_resolution)
@@ -165,53 +123,53 @@ if setup_grids:
 
 	grid_side_length = len(grid_x_values_S)
 
-	grid_lat_coords_S = (-np.arccos(((grid_xx_S**2 + grid_yy_S**2)**0.5)/planet_radius)*180.0/np.pi).flatten()
+	grid_lat_coords_S = (-np.arccos(((grid_xx_S**2 + grid_yy_S**2)**0.5)/planet_config.planet_radius)*180.0/np.pi).flatten()
 	grid_lon_coords_S = (180.0 - np.arctan2(grid_yy_S,grid_xx_S)*180.0/np.pi).flatten()
 
 	polar_x_coords_S = []
 	polar_y_coords_S = []
 	for i in range(pole_low_index_S):
-		for j in range(nlon):
-			polar_x_coords_S.append( planet_radius*np.cos(lat[i]*np.pi/180.0)*np.sin(lon[j]*np.pi/180.0) )
-			polar_y_coords_S.append(-planet_radius*np.cos(lat[i]*np.pi/180.0)*np.cos(lon[j]*np.pi/180.0) )
+		for j in range(coordinate_grid.nlon):
+			polar_x_coords_S.append( planet_config.planet_radius*np.cos(coordinate_grid.lat[i]*np.pi/180.0)*np.sin(coordinate_grid.lon[j]*np.pi/180.0) )
+			polar_y_coords_S.append(-planet_config.planet_radius*np.cos(coordinate_grid.lat[i]*np.pi/180.0)*np.cos(coordinate_grid.lon[j]*np.pi/180.0) )
 
 	### north pole ###
 	
-	pole_low_index_N  	= 	np.where(lat < -pole_lower_latitude_limit)[0][-1]
-	pole_high_index_N 	= 	np.where(lat < -pole_higher_latitude_limit)[0][-1]
+	pole_low_index_N  	= 	np.where(coordinate_grid.lat < -pole_lower_latitude_limit)[0][-1]
+	pole_high_index_N 	= 	np.where(coordinate_grid.lat < -pole_higher_latitude_limit)[0][-1]
 
 	grid_x_values_N 	= 	np.arange(-size_of_grid,size_of_grid,polar_grid_resolution)
 	grid_y_values_N 	= 	np.arange(-size_of_grid,size_of_grid,polar_grid_resolution)
 	grid_xx_N,grid_yy_N = 	np.meshgrid(grid_x_values_N,grid_y_values_N)
 
-	grid_lat_coords_N 	= 	(np.arccos((grid_xx_N**2 + grid_yy_N**2)**0.5/planet_radius)*180.0/np.pi).flatten()
+	grid_lat_coords_N 	= 	(np.arccos((grid_xx_N**2 + grid_yy_N**2)**0.5/planet_config.planet_radius)*180.0/np.pi).flatten()
 	grid_lon_coords_N 	= 	(180.0 - np.arctan2(grid_yy_N,grid_xx_N)*180.0/np.pi).flatten()
 
 	polar_x_coords_N 	= 	[]
 	polar_y_coords_N 	= 	[]
 
-	for i in np.arange(pole_low_index_N,nlat):
-		for j in range(nlon):
-			polar_x_coords_N.append( planet_radius*np.cos(lat[i]*np.pi/180.0)*np.sin(lon[j]*np.pi/180.0) )
-			polar_y_coords_N.append(-planet_radius*np.cos(lat[i]*np.pi/180.0)*np.cos(lon[j]*np.pi/180.0) )
+	for i in np.arange(pole_low_index_N,coordinate_grid.nlat):
+		for j in range(coordinate_grid.nlon):
+			polar_x_coords_N.append( planet_config.planet_radius*np.cos(coordinate_grid.lat[i]*np.pi/180.0)*np.sin(coordinate_grid.lon[j]*np.pi/180.0) )
+			polar_y_coords_N.append(-planet_config.planet_radius*np.cos(coordinate_grid.lat[i]*np.pi/180.0)*np.cos(coordinate_grid.lon[j]*np.pi/180.0) )
 
 	indices = (pole_low_index_N,pole_high_index_N,pole_low_index_S,pole_high_index_S)
 	grids   = (grid_xx_N.shape[0],grid_xx_S.shape[0])
 
 	# create Coriolis data on north and south planes
-	data = np.zeros((nlat-pole_low_index_N+grid_pad,nlon))
-	for i in np.arange(pole_low_index_N-grid_pad,nlat):
+	data = np.zeros((coordinate_grid.nlat-pole_low_index_N+grid_pad,coordinate_grid.nlon))
+	for i in np.arange(pole_low_index_N-grid_pad,coordinate_grid.nlat):
 		data[i-pole_low_index_N,:] = coriolis[i]
-	coriolis_plane_N = low_level.beam_me_up_2D(lat[(pole_low_index_N-grid_pad):],lon,data,grids[0],grid_lat_coords_N,grid_lon_coords_N)
-	data = np.zeros((pole_low_index_S+grid_pad,nlon))
+	coriolis_plane_N = low_level.beam_me_up_2D(coordinate_grid.lat[(pole_low_index_N-grid_pad):],coordinate_grid.lon,data,grids[0],grid_lat_coords_N,grid_lon_coords_N)
+	data = np.zeros((pole_low_index_S+grid_pad,coordinate_grid.nlon))
 	for i in range(pole_low_index_S+grid_pad):
 		data[i,:] = coriolis[i]
-	coriolis_plane_S = low_level.beam_me_up_2D(lat[:(pole_low_index_S+grid_pad)],lon,data,grids[1],grid_lat_coords_S,grid_lon_coords_S)
+	coriolis_plane_S = low_level.beam_me_up_2D(coordinate_grid.lat[:(pole_low_index_S+grid_pad)],coordinate_grid.lon,data,grids[1],grid_lat_coords_S,grid_lon_coords_S)
 
-	x_dot_N = np.zeros((grids[0],grids[0],nlevels))
-	y_dot_N = np.zeros((grids[0],grids[0],nlevels))
-	x_dot_S = np.zeros((grids[1],grids[1],nlevels))
-	y_dot_S = np.zeros((grids[1],grids[1],nlevels))
+	x_dot_N = np.zeros((grids[0],grids[0],planet_config.nlevels))
+	y_dot_N = np.zeros((grids[0],grids[0],planet_config.nlevels))
+	x_dot_S = np.zeros((grids[1],grids[1],planet_config.nlevels))
+	y_dot_S = np.zeros((grids[1],grids[1],planet_config.nlevels))
 
 	coords  = grid_lat_coords_N,grid_lon_coords_N,grid_x_values_N,grid_y_values_N,polar_x_coords_N,polar_y_coords_N,grid_lat_coords_S,grid_lon_coords_S,grid_x_values_S,grid_y_values_S,polar_x_coords_S,polar_y_coords_S
 
@@ -220,9 +178,9 @@ if setup_grids:
 # INITIATE TIME
 t = 0.0
 
-if load:
+if save_config.load:
 	# load in previous save file
-	potential_temperature,temperature_world,u,v,w,x_dot_N,y_dot_N,x_dot_S,y_dot_S,t,albedo,tracer = pickle.load(open("save_file.p","rb"))
+	potential_temperature,coordinate_grid.temperature_world,u,v,w,x_dot_N,y_dot_N,x_dot_S,y_dot_S,t,albedo,tracer = pickle.load(open("save_file.p","rb"))
 
 sample_level = 5
 tracer = np.zeros_like(potential_temperature)
@@ -230,58 +188,58 @@ tracer = np.zeros_like(potential_temperature)
 last_plot = t-0.1
 last_save = t-0.1
 
-if plot:
-	if not diagnostic:
+if view_config.plot:
+	if not view_config.diagnostic:
 		# set up plot
 		f, ax = plt.subplots(2,figsize=(9,9))
 		f.canvas.set_window_title('CLAuDE')
-		ax[0].contourf(lon_plot, lat_plot, temperature_world, cmap='seismic')
-		ax[0].streamplot(lon_plot, lat_plot, u[:,:,0], v[:,:,0], color='white',density=1)
-		test = ax[1].contourf(heights_plot, lat_z_plot, np.transpose(np.mean(low_level.theta_to_t(potential_temperature,pressure_levels),axis=1))[:top,:], cmap='seismic',levels=15)
-		ax[1].contour(heights_plot,lat_z_plot, np.transpose(np.mean(u,axis=1))[:top,:], colors='white',levels=20,linewidths=1,alpha=0.8)
-		ax[1].quiver(heights_plot, lat_z_plot, np.transpose(np.mean(v,axis=1))[:top,:],np.transpose(np.mean(10*w,axis=1))[:top,:],color='black')
+		ax[0].contourf(coordinate_grid.lon_plot, coordinate_grid.lat_plot, coordinate_grid.temperature_world, cmap='seismic')
+		ax[0].streamplot(coordinate_grid.lon_plot, coordinate_grid.lat_plot, u[:,:,0], v[:,:,0], color='white',density=1)
+		test = ax[1].contourf(coordinate_grid.heights_plot, coordinate_grid.lat_z_plot, np.transpose(np.mean(low_level.theta_to_t(potential_temperature,planet_config.pressure_levels),axis=1))[:view_config.top,:], cmap='seismic',levels=15)
+		ax[1].contour(coordinate_grid.heights_plot,coordinate_grid.lat_z_plot, np.transpose(np.mean(u,axis=1))[:view_config.top,:], colors='white',levels=20,linewidths=1,alpha=0.8)
+		ax[1].quiver(coordinate_grid.heights_plot, coordinate_grid.lat_z_plot, np.transpose(np.mean(v,axis=1))[:view_config.top,:],np.transpose(np.mean(10*w,axis=1))[:view_config.top,:],color='black')
 		plt.subplots_adjust(left=0.1, right=0.75)
 		ax[0].set_title('Surface temperature')
-		ax[0].set_xlim(lon.min(),lon.max())
+		ax[0].set_xlim(coordinate_grid.lon.min(),coordinate_grid.lon.max())
 		ax[1].set_title('Atmosphere temperature')
-		ax[1].set_xlim(lat.min(),lat.max())
-		ax[1].set_ylim((pressure_levels.max()/100,pressure_levels[:top].min()/100))
+		ax[1].set_xlim(coordinate_grid.lat.min(),coordinate_grid.lat.max())
+		ax[1].set_ylim((planet_config.pressure_levels.max()/100,planet_config.pressure_levels[:view_config.top].min()/100))
 		ax[1].set_yscale('log')		
 		ax[1].set_ylabel('Pressure (hPa)')
 		ax[1].set_xlabel('Latitude')
 		cbar_ax = f.add_axes([0.85, 0.15, 0.05, 0.7])
 		f.colorbar(test, cax=cbar_ax)
 		cbar_ax.set_title('Temperature (K)')
-		f.suptitle( 'Time ' + str(round(t/day,2)) + ' days' )
+		f.suptitle( 'Time ' + str(round(t/planet_config.day,2)) + ' days' )
 
 	else:
 		# set up plot
 		f, ax = plt.subplots(2,2,figsize=(9,9))
 		f.canvas.set_window_title('CLAuDE')
-		ax[0,0].contourf(heights_plot, lat_z_plot, np.transpose(np.mean(u,axis=1))[:top,:], cmap='seismic')
+		ax[0,0].contourf(coordinate_grid.heights_plot, coordinate_grid.lat_z_plot, np.transpose(np.mean(u,axis=1))[:view_config.top,:], cmap='seismic')
 		ax[0,0].set_title('u')
-		ax[0,1].contourf(heights_plot, lat_z_plot, np.transpose(np.mean(v,axis=1))[:top,:], cmap='seismic')
+		ax[0,1].contourf(coordinate_grid.heights_plot, coordinate_grid.lat_z_plot, np.transpose(np.mean(v,axis=1))[:view_config.top,:], cmap='seismic')
 		ax[0,1].set_title('v')
-		ax[1,0].contourf(heights_plot, lat_z_plot, np.transpose(np.mean(w,axis=1))[:top,:], cmap='seismic')
+		ax[1,0].contourf(coordinate_grid.heights_plot, coordinate_grid.lat_z_plot, np.transpose(np.mean(w,axis=1))[:view_config.top,:], cmap='seismic')
 		ax[1,0].set_title('w')
-		ax[1,1].contourf(heights_plot, lat_z_plot, np.transpose(np.mean(atmosp_addition,axis=1))[:top,:], cmap='seismic')
+		ax[1,1].contourf(coordinate_grid.heights_plot, coordinate_grid.lat_z_plot, np.transpose(np.mean(atmosp_addition,axis=1))[:view_config.top,:], cmap='seismic')
 		ax[1,1].set_title('atmosp_addition')
 		for axis in ax.ravel():
-			axis.set_ylim((pressure_levels.max()/100,pressure_levels[:top].min()/100))
+			axis.set_ylim((planet_config.pressure_levels.max()/100,planet_config.pressure_levels[:view_config.top].min()/100))
 			axis.set_yscale('log')
-		f.suptitle( 'Time ' + str(round(t/day,2)) + ' days' )
+		f.suptitle( 'Time ' + str(round(t/planet_config.day,2)) + ' days' )
 
-	if level_plots:
+	if view_config.level_plots:
 
-		level_divisions = int(np.floor(nlevels/nplots))
-		level_plots_levels = range(nlevels)[::level_divisions][::-1]
+		level_divisions = int(np.floor(planet_config.nlevels/view_config.nplots))
+		level_plots_levels = range(planet_config.nlevels)[::level_divisions][::-1]
 
-		g, bx = plt.subplots(nplots,figsize=(9,8),sharex=True)
+		g, bx = plt.subplots(view_config.nplots,figsize=(9,8),sharex=True)
 		g.canvas.set_window_title('CLAuDE pressure levels')
-		for k, z in zip(range(nplots), level_plots_levels):	
+		for k, z in zip(range(view_config.nplots), level_plots_levels):	
 			z += 1
-			bx[k].contourf(lon_plot, lat_plot, potential_temperature[:,:,z], cmap='seismic')
-			bx[k].set_title(str(pressure_levels[z]/100)+' hPa')
+			bx[k].contourf(coordinate_grid.lon_plot, coordinate_grid.lat_plot, potential_temperature[:,:,z], cmap='seismic')
+			bx[k].set_title(str(planet_config.pressure_levels[z]/100)+' hPa')
 			bx[k].set_ylabel('Latitude')
 		bx[-1].set_xlabel('Longitude')
 	
@@ -289,11 +247,11 @@ if plot:
 	plt.show()
 	plt.pause(2)
 
-	if not diagnostic:
+	if not view_config.diagnostic:
 		ax[0].cla()
 		ax[1].cla()
-		if level_plots:
-			for k in range(nplots):
+		if view_config.level_plots:
+			for k in range(view_config.nplots):
 				bx[k].cla()		
 	else:
 		ax[0,0].cla()
@@ -301,127 +259,127 @@ if plot:
 		ax[1,0].cla()
 		ax[1,1].cla()
 
-if above:
+if view_config.above:
 	g,gx = plt.subplots(1,3, figsize=(15,5))
 	plt.ion()
 	plt.show()
 
 def plotting_routine():
 	
-	quiver_padding = int(12/resolution)
+	quiver_padding = int(12/planet_config.resolution)
 
-	if plot:
-		if verbose:	before_plot = time.time()
+	if view_config.plot:
+		if view_config.verbose:	before_plot = time.time()
 		# update plot
-		if not diagnostic:
+		if not view_config.diagnostic:
 			
-			# ax[0].contourf(lon_plot, lat_plot, temperature_world, cmap='seismic',levels=15)
+			# ax[0].contourf(coordinate_grid.lon_plot, coordinate_grid.lat_plot, coordinate_grid.temperature_world, cmap='seismic',levels=15)
 					
 			# field = np.copy(w)[:,:,sample_level]
 			field = np.copy(atmosp_addition)[:,:,sample_level]
-			ax[0].contourf(lon_plot, lat_plot, field, cmap='seismic',levels=15)
-			ax[0].contour(lon_plot, lat_plot, tracer[:,:,sample_level], alpha=0.5, antialiased=True, levels=np.arange(0.01,1.01,0.01))
+			ax[0].contourf(coordinate_grid.lon_plot, coordinate_grid.lat_plot, field, cmap='seismic',levels=15)
+			ax[0].contour(coordinate_grid.lon_plot, coordinate_grid.lat_plot, tracer[:,:,sample_level], alpha=0.5, antialiased=True, levels=np.arange(0.01,1.01,0.01))
 			
-			if velocity:	ax[0].quiver(lon_plot[::quiver_padding,::quiver_padding], lat_plot[::quiver_padding,::quiver_padding], u[::quiver_padding,::quiver_padding,sample_level], v[::quiver_padding,::quiver_padding,sample_level], color='white')
+			if velocity:	ax[0].quiver(coordinate_grid.lon_plot[::quiver_padding,::quiver_padding], coordinate_grid.lat_plot[::quiver_padding,::quiver_padding], u[::quiver_padding,::quiver_padding,sample_level], v[::quiver_padding,::quiver_padding,sample_level], color='white')
 			# ax[0].set_title('$\it{Ground} \quad \it{temperature}$')
 
-			ax[0].set_xlim((lon.min(),lon.max()))
-			ax[0].set_ylim((lat.min(),lat.max()))
+			ax[0].set_xlim((coordinate_grid.lon.min(),coordinate_grid.lon.max()))
+			ax[0].set_ylim((coordinate_grid.lat.min(),coordinate_grid.lat.max()))
 			ax[0].set_ylabel('Latitude')
 			ax[0].axhline(y=0,color='black',alpha=0.3)
 			ax[0].set_xlabel('Longitude')
 
-			test = ax[1].contourf(heights_plot, lat_z_plot, np.transpose(np.mean(low_level.theta_to_t(potential_temperature,pressure_levels),axis=1))[:top,:], cmap='seismic',levels=15)
-			# test = ax[1].contourf(heights_plot, lat_z_plot, np.transpose(np.mean(atmosp_addition,axis=1))[:top,:], cmap='seismic',levels=15)
-			# test = ax[1].contourf(heights_plot, lat_z_plot, np.transpose(np.mean(potential_temperature,axis=1)), cmap='seismic',levels=15)
-			ax[1].contour(heights_plot, lat_z_plot, np.transpose(np.mean(tracer,axis=1))[:top,:], alpha=0.5, antialiased=True, levels=np.arange(0.001,1.01,0.01))
+			test = ax[1].contourf(coordinate_grid.heights_plot, coordinate_grid.lat_z_plot, np.transpose(np.mean(low_level.theta_to_t(potential_temperature,planet_config.pressure_levels),axis=1))[:view_config.top,:], cmap='seismic',levels=15)
+			# test = ax[1].contourf(coordinate_grid.heights_plot, coordinate_grid.lat_z_plot, np.transpose(np.mean(atmosp_addition,axis=1))[:view_config.top,:], cmap='seismic',levels=15)
+			# test = ax[1].contourf(coordinate_grid.heights_plot, coordinate_grid.lat_z_plot, np.transpose(np.mean(potential_temperature,axis=1)), cmap='seismic',levels=15)
+			ax[1].contour(coordinate_grid.heights_plot, coordinate_grid.lat_z_plot, np.transpose(np.mean(tracer,axis=1))[:view_config.top,:], alpha=0.5, antialiased=True, levels=np.arange(0.001,1.01,0.01))
 
 			if velocity:
-				ax[1].contour(heights_plot,lat_z_plot, np.transpose(np.mean(u,axis=1))[:top,:], colors='white',levels=20,linewidths=1,alpha=0.8)
-				ax[1].quiver(heights_plot, lat_z_plot, np.transpose(np.mean(v,axis=1))[:top,:],np.transpose(np.mean(5*w,axis=1))[:top,:],color='black')
+				ax[1].contour(coordinate_grid.heights_plot,coordinate_grid.lat_z_plot, np.transpose(np.mean(u,axis=1))[:view_config.top,:], colors='white',levels=20,linewidths=1,alpha=0.8)
+				ax[1].quiver(coordinate_grid.heights_plot, coordinate_grid.lat_z_plot, np.transpose(np.mean(v,axis=1))[:view_config.top,:],np.transpose(np.mean(5*w,axis=1))[:view_config.top,:],color='black')
 			ax[1].set_title('$\it{Atmospheric} \quad \it{temperature}$')
 			ax[1].set_xlim((-90,90))
-			ax[1].set_ylim((pressure_levels.max()/100,pressure_levels[:top].min()/100))
+			ax[1].set_ylim((planet_config.pressure_levels.max()/100,planet_config.pressure_levels[:view_config.top].min()/100))
 			ax[1].set_ylabel('Pressure (hPa)')
 			ax[1].set_xlabel('Latitude')
 			ax[1].set_yscale('log')
 			f.colorbar(test, cax=cbar_ax)
 			cbar_ax.set_title('Temperature (K)')
-			f.suptitle( 'Time ' + str(round(t/day,2)) + ' days' )
+			f.suptitle( 'Time ' + str(round(t/planet_config.day,2)) + ' days' )
 				
 		else:
-			ax[0,0].contourf(heights_plot, lat_z_plot, np.transpose(np.mean(u,axis=1))[:top,:], cmap='seismic')
+			ax[0,0].contourf(coordinate_grid.heights_plot, coordinate_grid.lat_z_plot, np.transpose(np.mean(u,axis=1))[:view_config.top,:], cmap='seismic')
 			ax[0,0].set_title('u')
-			ax[0,1].contourf(heights_plot, lat_z_plot, np.transpose(np.mean(v,axis=1))[:top,:], cmap='seismic')
+			ax[0,1].contourf(coordinate_grid.heights_plot, coordinate_grid.lat_z_plot, np.transpose(np.mean(v,axis=1))[:view_config.top,:], cmap='seismic')
 			ax[0,1].set_title('v')
-			ax[1,0].contourf(heights_plot, lat_z_plot, np.transpose(np.mean(w,axis=1))[:top,:], cmap='seismic')
+			ax[1,0].contourf(coordinate_grid.heights_plot, coordinate_grid.lat_z_plot, np.transpose(np.mean(w,axis=1))[:view_config.top,:], cmap='seismic')
 			ax[1,0].set_title('w')
-			ax[1,1].contourf(heights_plot, lat_z_plot, np.transpose(np.mean(atmosp_addition,axis=1))[:top,:], cmap='seismic')
+			ax[1,1].contourf(coordinate_grid.heights_plot, coordinate_grid.lat_z_plot, np.transpose(np.mean(atmosp_addition,axis=1))[:view_config.top,:], cmap='seismic')
 			ax[1,1].set_title('atmosp_addition')
 			for axis in ax.ravel():
-				axis.set_ylim((pressure_levels.max()/100,pressure_levels[:top].min()/100))
+				axis.set_ylim((planet_config.pressure_levels.max()/100,planet_config.pressure_levels[:view_config.top].min()/100))
 				axis.set_yscale('log')
-			f.suptitle( 'Time ' + str(round(t/day,2)) + ' days' )
+			f.suptitle( 'Time ' + str(round(t/planet_config.day,2)) + ' days' )
 
-		if level_plots:
-			for k, z in zip(range(nplots), level_plots_levels):	
+		if view_config.level_plots:
+			for k, z in zip(range(view_config.nplots), level_plots_levels):	
 				z += 1
-				bx[k].contourf(lon_plot, lat_plot, potential_temperature[:,:,z], cmap='seismic',levels=15)
-				bx[k].quiver(lon_plot[::quiver_padding,::quiver_padding], lat_plot[::quiver_padding,::quiver_padding], u[::quiver_padding,::quiver_padding,z], v[::quiver_padding,::quiver_padding,z], color='white')
-				bx[k].set_title(str(round(pressure_levels[z]/100))+' hPa')
+				bx[k].contourf(coordinate_grid.lon_plot, coordinate_grid.lat_plot, potential_temperature[:,:,z], cmap='seismic',levels=15)
+				bx[k].quiver(coordinate_grid.lon_plot[::quiver_padding,::quiver_padding], coordinate_grid.lat_plot[::quiver_padding,::quiver_padding], u[::quiver_padding,::quiver_padding,z], v[::quiver_padding,::quiver_padding,z], color='white')
+				bx[k].set_title(str(round(planet_config.pressure_levels[z]/100))+' hPa')
 				bx[k].set_ylabel('Latitude')
-				bx[k].set_xlim((lon.min(),lon.max()))
-				bx[k].set_ylim((lat.min(),lat.max()))				
+				bx[k].set_xlim((coordinate_grid.lon.min(),coordinate_grid.lon.max()))
+				bx[k].set_ylim((coordinate_grid.lat.min(),coordinate_grid.lat.max()))				
 			bx[-1].set_xlabel('Longitude')
 
-	if above and velocity:
+	if view_config.above and velocity:
 		gx[0].set_title('Original data')
 		gx[1].set_title('Polar plane')
 		gx[2].set_title('Reprojected data')
-		g.suptitle( 'Time ' + str(round(t/day,2)) + ' days' )
+		g.suptitle( 'Time ' + str(round(t/planet_config.day,2)) + ' days' )
 
-		if pole == 's':
+		if view_config.pole == PoleType.SOUTH:
 			gx[0].set_title('temperature')
-			gx[0].contourf(lon,lat[:pole_low_index_S],potential_temperature[:pole_low_index_S,:,above_level])
+			gx[0].contourf(coordinate_grid.lon,coordinate_grid.lat[:pole_low_index_S],potential_temperature[:pole_low_index_S,:,view_config.view_config.above_level])
 			
 			gx[1].set_title('polar_plane_advect')
-			polar_temps = low_level.beam_me_up(lat[:pole_low_index_S],lon,potential_temperature[:pole_low_index_S,:,:],grids[1],grid_lat_coords_S,grid_lon_coords_S)
-			output = low_level.beam_me_up(lat[:pole_low_index_S],lon,south_reprojected_addition,grids[1],grid_lat_coords_S,grid_lon_coords_S)
+			polar_temps = low_level.beam_me_up(coordinate_grid.lat[:pole_low_index_S],coordinate_grid.lon,potential_temperature[:pole_low_index_S,:,:],grids[1],grid_lat_coords_S,grid_lon_coords_S)
+			output = low_level.beam_me_up(coordinate_grid.lat[:pole_low_index_S],coordinate_grid.lon,south_reprojected_addition,grids[1],grid_lat_coords_S,grid_lon_coords_S)
 
-			gx[1].contourf(grid_x_values_S/1E3,grid_y_values_S/1E3,output[:,:,above_level])
-			gx[1].contour(grid_x_values_S/1E3,grid_y_values_S/1E3,polar_temps[:,:,above_level],colors='white',levels=20,linewidths=1,alpha=0.8)
-			gx[1].quiver(grid_x_values_S/1E3,grid_y_values_S/1E3,x_dot_S[:,:,above_level],y_dot_S[:,:,above_level])
+			gx[1].contourf(grid_x_values_S/1E3,grid_y_values_S/1E3,output[:,:,view_config.view_config.above_level])
+			gx[1].contour(grid_x_values_S/1E3,grid_y_values_S/1E3,polar_temps[:,:,view_config.view_config.above_level],colors='white',levels=20,linewidths=1,alpha=0.8)
+			gx[1].quiver(grid_x_values_S/1E3,grid_y_values_S/1E3,x_dot_S[:,:,view_config.view_config.above_level],y_dot_S[:,:,view_config.above_level])
 			
-			gx[1].add_patch(plt.Circle((0,0),planet_radius*np.cos(lat[pole_low_index_S]*np.pi/180.0)/1E3,color='r',fill=False))
-			gx[1].add_patch(plt.Circle((0,0),planet_radius*np.cos(lat[pole_high_index_S]*np.pi/180.0)/1E3,color='r',fill=False))
+			gx[1].add_patch(plt.Circle((0,0),planet_config.planet_radius*np.cos(coordinate_grid.lat[pole_low_index_S]*np.pi/180.0)/1E3,color='r',fill=False))
+			gx[1].add_patch(plt.Circle((0,0),planet_config.planet_radius*np.cos(coordinate_grid.lat[pole_high_index_S]*np.pi/180.0)/1E3,color='r',fill=False))
 
 			gx[2].set_title('south_addition_smoothed')
-			gx[2].contourf(lon,lat[:pole_low_index_S],south_addition_smoothed[:pole_low_index_S,:,above_level])
-			# gx[2].contourf(lon,lat[:pole_low_index_S],u[:pole_low_index_S,:,above_level])
-			gx[2].quiver(lon[::5],lat[:pole_low_index_S],u[:pole_low_index_S,::5,above_level],v[:pole_low_index_S,::5,above_level])
+			gx[2].contourf(coordinate_grid.lon,coordinate_grid.lat[:pole_low_index_S],south_addition_smoothed[:pole_low_index_S,:,view_config.above_level])
+			# gx[2].contourf(coordinate_grid.lon,coordinate_grid.lat[:pole_low_index_S],u[:pole_low_index_S,:,view_config.above_level])
+			gx[2].quiver(coordinate_grid.lon[::5],coordinate_grid.lat[:pole_low_index_S],u[:pole_low_index_S,::5,view_config.above_level],v[:pole_low_index_S,::5,view_config.above_level])
 		else:
 			gx[0].set_title('temperature')
-			gx[0].contourf(lon,lat[pole_low_index_N:],potential_temperature[pole_low_index_N:,:,above_level])
+			gx[0].contourf(coordinate_grid.lon,coordinate_grid.lat[pole_low_index_N:],potential_temperature[pole_low_index_N:,:,view_config.above_level])
 			
 			gx[1].set_title('polar_plane_advect')
-			polar_temps = low_level.beam_me_up(lat[pole_low_index_N:],lon,np.flip(potential_temperature[pole_low_index_N:,:,:],axis=1),grids[0],grid_lat_coords_N,grid_lon_coords_N)
-			output = low_level.beam_me_up(lat[pole_low_index_N:],lon,north_reprojected_addition,grids[0],grid_lat_coords_N,grid_lon_coords_N)
-			gx[1].contourf(grid_x_values_N/1E3,grid_y_values_N/1E3,output[:,:,above_level])
-			gx[1].contour(grid_x_values_N/1E3,grid_y_values_N/1E3,polar_temps[:,:,above_level],colors='white',levels=20,linewidths=1,alpha=0.8)
-			gx[1].quiver(grid_x_values_N/1E3,grid_y_values_N/1E3,x_dot_N[:,:,above_level],y_dot_N[:,:,above_level])
+			polar_temps = low_level.beam_me_up(coordinate_grid.lat[pole_low_index_N:],coordinate_grid.lon,np.flip(potential_temperature[pole_low_index_N:,:,:],axis=1),grids[0],grid_lat_coords_N,grid_lon_coords_N)
+			output = low_level.beam_me_up(coordinate_grid.lat[pole_low_index_N:],coordinate_grid.lon,north_reprojected_addition,grids[0],grid_lat_coords_N,grid_lon_coords_N)
+			gx[1].contourf(grid_x_values_N/1E3,grid_y_values_N/1E3,output[:,:,view_config.above_level])
+			gx[1].contour(grid_x_values_N/1E3,grid_y_values_N/1E3,polar_temps[:,:,view_config.above_level],colors='white',levels=20,linewidths=1,alpha=0.8)
+			gx[1].quiver(grid_x_values_N/1E3,grid_y_values_N/1E3,x_dot_N[:,:,view_config.above_level],y_dot_N[:,:,view_config.above_level])
 			
-			gx[1].add_patch(plt.Circle((0,0),planet_radius*np.cos(lat[pole_low_index_N]*np.pi/180.0)/1E3,color='r',fill=False))
-			gx[1].add_patch(plt.Circle((0,0),planet_radius*np.cos(lat[pole_high_index_N]*np.pi/180.0)/1E3,color='r',fill=False))
+			gx[1].add_patch(plt.Circle((0,0),planet_config.planet_radius*np.cos(coordinate_grid.lat[pole_low_index_N]*np.pi/180.0)/1E3,color='r',fill=False))
+			gx[1].add_patch(plt.Circle((0,0),planet_config.planet_radius*np.cos(coordinate_grid.lat[pole_high_index_N]*np.pi/180.0)/1E3,color='r',fill=False))
 	
 			gx[2].set_title('south_addition_smoothed')
-			# gx[2].contourf(lon,lat[pole_low_index_N:],north_addition_smoothed[:,:,above_level])
-			gx[2].contourf(lon,lat[pole_low_index_N:],u[pole_low_index_N:,:,above_level])
-			gx[2].quiver(lon[::5],lat[pole_low_index_N:],u[pole_low_index_N:,::5,above_level],v[pole_low_index_N:,::5,above_level])
+			# gx[2].contourf(coordinate_grid.lon,coordinate_grid.lat[pole_low_index_N:],north_addition_smoothed[:,:,view_config.above_level])
+			gx[2].contourf(coordinate_grid.lon,coordinate_grid.lat[pole_low_index_N:],u[pole_low_index_N:,:,view_config.above_level])
+			gx[2].quiver(coordinate_grid.lon[::5],coordinate_grid.lat[pole_low_index_N:],u[pole_low_index_N:,::5,view_config.above_level],v[pole_low_index_N:,::5,view_config.above_level])
 		
 	# clear plots
-	if plot or above:	plt.pause(0.001)
-	if plot:
-		if not diagnostic:
+	if view_config.plot or view_config.above:	plt.pause(0.001)
+	if view_config.plot:
+		if not view_config.diagnostic:
 			ax[0].cla()
 			ax[1].cla()
 			cbar_ax.cla()
@@ -431,13 +389,13 @@ def plotting_routine():
 			ax[0,1].cla()
 			ax[1,0].cla()
 			ax[1,1].cla()
-		if level_plots:
-			for k in range(nplots):
+		if view_config.level_plots:
+			for k in range(view_config.nplots):
 				bx[k].cla()	
-		if verbose:		
+		if view_config.verbose:		
 			time_taken = float(round(time.time() - before_plot,3))
 			print('Plotting: ',str(time_taken),'s')	
-	if above:
+	if view_config.above:
 		gx[0].cla()
 		gx[1].cla()
 		gx[2].cla()
@@ -454,103 +412,103 @@ while True:
 		velocity = True
 
 	# print current time in simulation to command line
-	print("+++ t = " + str(round(t/day,2)) + " days +++")
-	print('T: ',round(temperature_world.max()-273.15,1),' - ',round(temperature_world.min()-273.15,1),' C')
+	print("+++ t = " + str(round(t/planet_config.day,2)) + " days +++")
+	print('T: ',round(coordinate_grid.temperature_world.max()-273.15,1),' - ',round(coordinate_grid.temperature_world.min()-273.15,1),' C')
 	print('U: ',round(u.max(),2),' - ',round(u.min(),2),' V: ',round(v.max(),2),' - ',round(v.min(),2),' W: ',round(w.max(),2),' - ',round(w.min(),4))
 
 	tracer[40,50,sample_level] = 1
 	tracer[20,50,sample_level] = 1
 
-	if verbose: before_radiation = time.time()
-	temperature_world, potential_temperature = top_level.radiation_calculation(temperature_world, potential_temperature, pressure_levels, heat_capacity_earth, albedo, insolation, lat, lon, t, dt, day, year, axial_tilt)
-	if smoothing: potential_temperature = top_level.smoothing_3D(potential_temperature,smoothing_parameter_t)
-	if verbose:
+	if view_config.verbose: before_radiation = time.time()
+	coordinate_grid.temperature_world, potential_temperature = top_level.radiation_calculation(coordinate_grid.temperature_world, potential_temperature, planet_config.pressure_levels, heat_capacity_earth, albedo, planet_config.insolation, coordinate_grid.lat, coordinate_grid.lon, t, dt, planet_config.day, planet_config.year, planet_config.axial_tilt)
+	if smoothing_config.smoothing: potential_temperature = top_level.smoothing_3D(potential_temperature,smoothing_config.smoothing_parameter_t)
+	if view_config.verbose:
 		time_taken = float(round(time.time() - before_radiation,3))
 		print('Radiation: ',str(time_taken),'s')
 
-	diffusion = top_level.laplacian_2d(temperature_world,dx,dy)
+	diffusion = top_level.laplacian_2d(coordinate_grid.temperature_world,dx,dy)
 	diffusion[0,:] = np.mean(diffusion[1,:],axis=0)
 	diffusion[-1,:] = np.mean(diffusion[-2,:],axis=0)
-	temperature_world -= dt*1E-5*diffusion
+	coordinate_grid.temperature_world -= dt*1E-5*diffusion
 
 	# update geopotential field
 	geopotential = np.zeros_like(potential_temperature)
-	for k in np.arange(1,nlevels):	geopotential[:,:,k] = geopotential[:,:,k-1] - potential_temperature[:,:,k]*(sigma[k]-sigma[k-1])
+	for k in np.arange(1,planet_config.nlevels):	geopotential[:,:,k] = geopotential[:,:,k-1] - potential_temperature[:,:,k]*(sigma[k]-sigma[k-1])
 
 	if velocity:
 
-		if verbose:	before_velocity = time.time()
+		if view_config.verbose:	before_velocity = time.time()
 		
-		u_add,v_add = top_level.velocity_calculation(u,v,w,pressure_levels,geopotential,potential_temperature,coriolis,gravity,dx,dy,dt)
+		u_add,v_add = top_level.velocity_calculation(u,v,w,planet_config.pressure_levels,geopotential,potential_temperature,coriolis,planet_config.gravity,dx,dy,dt)
 
-		if verbose:	
+		if view_config.verbose:	
 			time_taken = float(round(time.time() - before_velocity,3))
 			print('Velocity: ',str(time_taken),'s')
 
-		if verbose:	before_projection = time.time()
+		if view_config.verbose:	before_projection = time.time()
 		
 		grid_velocities = (x_dot_N,y_dot_N,x_dot_S,y_dot_S)
 	
-		u_add,v_add,north_reprojected_addition,south_reprojected_addition,x_dot_N,y_dot_N,x_dot_S,y_dot_S = top_level.polar_planes(u,v,u_add,v_add,potential_temperature,geopotential,grid_velocities,indices,grids,coords,coriolis_plane_N,coriolis_plane_S,grid_side_length,pressure_levels,lat,lon,dt,polar_grid_resolution,gravity)
+		u_add,v_add,north_reprojected_addition,south_reprojected_addition,x_dot_N,y_dot_N,x_dot_S,y_dot_S = top_level.polar_planes(u,v,u_add,v_add,potential_temperature,geopotential,grid_velocities,indices,grids,coords,coriolis_plane_N,coriolis_plane_S,grid_side_length,planet_config.pressure_levels,coordinate_grid.lat,coordinate_grid.lon,dt,polar_grid_resolution,planet_config.gravity)
 		
 		u += u_add
 		v += v_add
 
-		if smoothing: u = top_level.smoothing_3D(u,smoothing_parameter_u)
-		if smoothing: v = top_level.smoothing_3D(v,smoothing_parameter_v)
+		if smoothing_config.smoothing: u = top_level.smoothing_3D(u,smoothing_config.smoothing_parameter_u)
+		if smoothing_config.smoothing: v = top_level.smoothing_3D(v,smoothing_config.smoothing_parameter_v)
 
-		x_dot_N,y_dot_N,x_dot_S,y_dot_S = top_level.update_plane_velocities(lat,lon,pole_low_index_N,pole_low_index_S,np.flip(u[pole_low_index_N:,:,:],axis=1),np.flip(v[pole_low_index_N:,:,:],axis=1),grids,grid_lat_coords_N,grid_lon_coords_N,u[:pole_low_index_S,:,:],v[:pole_low_index_S,:,:],grid_lat_coords_S,grid_lon_coords_S)
+		x_dot_N,y_dot_N,x_dot_S,y_dot_S = top_level.update_plane_velocities(coordinate_grid.lat,coordinate_grid.lon,pole_low_index_N,pole_low_index_S,np.flip(u[pole_low_index_N:,:,:],axis=1),np.flip(v[pole_low_index_N:,:,:],axis=1),grids,grid_lat_coords_N,grid_lon_coords_N,u[:pole_low_index_S,:,:],v[:pole_low_index_S,:,:],grid_lat_coords_S,grid_lon_coords_S)
 		
-		if verbose:	
+		if view_config.verbose:	
 			time_taken = float(round(time.time() - before_projection,3))
 			print('Projection: ',str(time_taken),'s')
 
 		### allow for thermal advection in the atmosphere
-		if verbose:	before_advection = time.time()
+		if view_config.verbose:	before_advection = time.time()
 
 
 
-		if verbose: before_w = time.time()
+		if view_config.verbose: before_w = time.time()
 		# using updated u,v fields calculated w
 		# https://www.sjsu.edu/faculty/watkins/omega.htm
-		w = top_level.w_calculation(u,v,w,pressure_levels,geopotential,potential_temperature,coriolis,gravity,dx,dy,dt)
-		if smoothing: w = top_level.smoothing_3D(w,smoothing_parameter_w,0.25)
+		w = top_level.w_calculation(u,v,w,planet_config.pressure_levels,geopotential,potential_temperature,coriolis,planet_config.gravity,dx,dy,dt)
+		if smoothing_config.smoothing: w = top_level.smoothing_3D(w,smoothing_config.smoothing_parameter_w,0.25)
 
-		theta_N = low_level.beam_me_up(lat[pole_low_index_N:],lon,potential_temperature[pole_low_index_N:,:,:],grids[0],grid_lat_coords_N,grid_lon_coords_N)
-		w_N = top_level.w_plane(x_dot_N,y_dot_N,theta_N,pressure_levels,polar_grid_resolution,gravity)
-		w_N = np.flip(low_level.beam_me_down(lon,w_N,pole_low_index_N, grid_x_values_N, grid_y_values_N,polar_x_coords_N, polar_y_coords_N),axis=1)
-		w[pole_low_index_N:,:,:] = low_level.combine_data(pole_low_index_N,pole_high_index_N,w[pole_low_index_N:,:,:],w_N,lat)
+		theta_N = low_level.beam_me_up(coordinate_grid.lat[pole_low_index_N:],coordinate_grid.lon,potential_temperature[pole_low_index_N:,:,:],grids[0],grid_lat_coords_N,grid_lon_coords_N)
+		w_N = top_level.w_plane(x_dot_N,y_dot_N,theta_N,planet_config.pressure_levels,polar_grid_resolution,planet_config.gravity)
+		w_N = np.flip(low_level.beam_me_down(coordinate_grid.lon,w_N,pole_low_index_N, grid_x_values_N, grid_y_values_N,polar_x_coords_N, polar_y_coords_N),axis=1)
+		w[pole_low_index_N:,:,:] = low_level.combine_data(pole_low_index_N,pole_high_index_N,w[pole_low_index_N:,:,:],w_N,coordinate_grid.lat)
 		
-		w_S = top_level.w_plane(x_dot_S,y_dot_S,low_level.beam_me_up(lat[:pole_low_index_S],lon,potential_temperature[:pole_low_index_S,:,:],grids[1],grid_lat_coords_S,grid_lon_coords_S),pressure_levels,polar_grid_resolution,gravity)
-		w_S = low_level.beam_me_down(lon,w_S,pole_low_index_S, grid_x_values_S, grid_y_values_S,polar_x_coords_S, polar_y_coords_S)
-		w[:pole_low_index_S,:,:] = low_level.combine_data(pole_low_index_S,pole_high_index_S,w[:pole_low_index_S,:,:],w_S,lat)
+		w_S = top_level.w_plane(x_dot_S,y_dot_S,low_level.beam_me_up(coordinate_grid.lat[:pole_low_index_S],coordinate_grid.lon,potential_temperature[:pole_low_index_S,:,:],grids[1],grid_lat_coords_S,grid_lon_coords_S),planet_config.pressure_levels,polar_grid_resolution,planet_config.gravity)
+		w_S = low_level.beam_me_down(coordinate_grid.lon,w_S,pole_low_index_S, grid_x_values_S, grid_y_values_S,polar_x_coords_S, polar_y_coords_S)
+		w[:pole_low_index_S,:,:] = low_level.combine_data(pole_low_index_S,pole_high_index_S,w[:pole_low_index_S,:,:],w_S,coordinate_grid.lat)
 
-		# for k in np.arange(1,nlevels-1):
-		# 	north_reprojected_addition[:,:,k] += 0.5*(w_N[:,:,k] + abs(w_N[:,:,k]))*(potential_temperature[pole_low_index_N:,:,k] - potential_temperature[pole_low_index_N:,:,k-1])/(pressure_levels[k] - pressure_levels[k-1])
-		# 	north_reprojected_addition[:,:,k] += 0.5*(w_N[:,:,k] - abs(w_N[:,:,k]))*(potential_temperature[pole_low_index_N:,:,k+1] - potential_temperature[pole_low_index_N:,:,k])/(pressure_levels[k+1] - pressure_levels[k])
+		# for k in np.arange(1,planet_config.nlevels-1):
+		# 	north_reprojected_addition[:,:,k] += 0.5*(w_N[:,:,k] + abs(w_N[:,:,k]))*(potential_temperature[pole_low_index_N:,:,k] - potential_temperature[pole_low_index_N:,:,k-1])/(planet_config.pressure_levels[k] - planet_config.pressure_levels[k-1])
+		# 	north_reprojected_addition[:,:,k] += 0.5*(w_N[:,:,k] - abs(w_N[:,:,k]))*(potential_temperature[pole_low_index_N:,:,k+1] - potential_temperature[pole_low_index_N:,:,k])/(planet_config.pressure_levels[k+1] - planet_config.pressure_levels[k])
 
-		# 	south_reprojected_addition[:,:,k] += 0.5*(w_S[:,:,k] + abs(w_S[:,:,k]))*(potential_temperature[:pole_low_index_S,:,k] - potential_temperature[:pole_low_index_S,:,k-1])/(pressure_levels[k] - pressure_levels[k-1])
-		# 	south_reprojected_addition[:,:,k] += 0.5*(w_S[:,:,k] - abs(w_S[:,:,k]))*(potential_temperature[:pole_low_index_S,:,k+1] - potential_temperature[:pole_low_index_S,:,k])/(pressure_levels[k+1] - pressure_levels[k])
+		# 	south_reprojected_addition[:,:,k] += 0.5*(w_S[:,:,k] + abs(w_S[:,:,k]))*(potential_temperature[:pole_low_index_S,:,k] - potential_temperature[:pole_low_index_S,:,k-1])/(planet_config.pressure_levels[k] - planet_config.pressure_levels[k-1])
+		# 	south_reprojected_addition[:,:,k] += 0.5*(w_S[:,:,k] - abs(w_S[:,:,k]))*(potential_temperature[:pole_low_index_S,:,k+1] - potential_temperature[:pole_low_index_S,:,k])/(planet_config.pressure_levels[k+1] - planet_config.pressure_levels[k])
 
 		w[:,:,18:] *= 0
 
-		if verbose:	
+		if view_config.verbose:	
 			time_taken = float(round(time.time() - before_w,3))
 			print('Calculate w: ',str(time_taken),'s')
 
 		#################################
 
-		atmosp_addition = top_level.divergence_with_scalar(potential_temperature,u,v,w,dx,dy,pressure_levels)
+		atmosp_addition = top_level.divergence_with_scalar(potential_temperature,u,v,w,dx,dy,planet_config.pressure_levels)
 
 		# combine addition calculated on polar grid with that calculated on the cartestian grid
-		north_addition_smoothed = low_level.combine_data(pole_low_index_N,pole_high_index_N,atmosp_addition[pole_low_index_N:,:,:],north_reprojected_addition,lat)
-		south_addition_smoothed = low_level.combine_data(pole_low_index_S,pole_high_index_S,atmosp_addition[:pole_low_index_S,:,:],south_reprojected_addition,lat)
+		north_addition_smoothed = low_level.combine_data(pole_low_index_N,pole_high_index_N,atmosp_addition[pole_low_index_N:,:,:],north_reprojected_addition,coordinate_grid.lat)
+		south_addition_smoothed = low_level.combine_data(pole_low_index_S,pole_high_index_S,atmosp_addition[:pole_low_index_S,:,:],south_reprojected_addition,coordinate_grid.lat)
 		
 		# add the blended/combined addition to global temperature addition array
 		atmosp_addition[:pole_low_index_S,:,:] = south_addition_smoothed
 		atmosp_addition[pole_low_index_N:,:,:] = north_addition_smoothed
 
-		if smoothing: atmosp_addition = top_level.smoothing_3D(atmosp_addition,smoothing_parameter_add)
+		if smoothing_config.smoothing: atmosp_addition = top_level.smoothing_3D(atmosp_addition,smoothing_config.smoothing_parameter_add)
 
 		atmosp_addition[:,:,17] *= 0.5
 		atmosp_addition[:,:,18:] *= 0
@@ -559,35 +517,35 @@ while True:
 
 		###################################################################
 
-		tracer_addition = top_level.divergence_with_scalar(tracer,u,v,w,dx,dy,pressure_levels)
+		tracer_addition = top_level.divergence_with_scalar(tracer,u,v,w,dx,dy,planet_config.pressure_levels)
 		tracer_addition[:4,:,:] *= 0
 		tracer_addition[-4:,:,:] *= 0
 
-		for k in np.arange(1,nlevels-1):
+		for k in np.arange(1,planet_config.nlevels-1):
 
-			tracer_addition[:,:,k] += 0.5*(w[:,:,k] - abs(w[:,:,k]))*(tracer[:,:,k] - tracer[:,:,k-1])/(pressure_levels[k] - pressure_levels[k-1])
-			tracer_addition[:,:,k] += 0.5*(w[:,:,k] + abs(w[:,:,k]))*(tracer[:,:,k+1] - tracer[:,:,k])/(pressure_levels[k] - pressure_levels[k-1])
+			tracer_addition[:,:,k] += 0.5*(w[:,:,k] - abs(w[:,:,k]))*(tracer[:,:,k] - tracer[:,:,k-1])/(planet_config.pressure_levels[k] - planet_config.pressure_levels[k-1])
+			tracer_addition[:,:,k] += 0.5*(w[:,:,k] + abs(w[:,:,k]))*(tracer[:,:,k+1] - tracer[:,:,k])/(planet_config.pressure_levels[k] - planet_config.pressure_levels[k-1])
 
 		tracer -= dt*tracer_addition
 
-		diffusion = top_level.laplacian_3d(potential_temperature,dx,dy,pressure_levels)
+		diffusion = top_level.laplacian_3d(potential_temperature,dx,dy,planet_config.pressure_levels)
 		diffusion[0,:,:] = np.mean(diffusion[1,:,:],axis=0)
 		diffusion[-1,:,:] = np.mean(diffusion[-2,:,:],axis=0)
 		potential_temperature -= dt*1E-4*diffusion
 
 		###################################################################
 
-		if verbose:	
+		if view_config.verbose:	
 			time_taken = float(round(time.time() - before_advection,3))
 			print('Advection: ',str(time_taken),'s')
 
-	if t-last_plot >= plot_frequency*dt:
+	if t-last_plot >= save_config.plot_frequency*dt:
 		plotting_routine()
 		last_plot = t
 
-	if save:
-		if t-last_save >= save_frequency*dt:
-			pickle.dump((potential_temperature,temperature_world,u,v,w,x_dot_N,y_dot_N,x_dot_S,y_dot_S,t,albedo,tracer), open("save_file.p","wb"))
+	if save_config.save:
+		if t-last_save >= save_config.save_frequency*dt:
+			pickle.dump((potential_temperature,coordinate_grid.temperature_world,u,v,w,x_dot_N,y_dot_N,x_dot_S,y_dot_S,t,albedo,tracer), open("save_file.p","wb"))
 			last_save = t
 
 	if np.isnan(u.max()):


### PR DESCRIPTION
This request separates the constants out into YAML config files in order to allow for adjusting how the model works without requiring edits directly to Python code. This has been done in an Object-Oriented manner using PyYAML's available mapping facilities. Tests have been added to ensure that loading works as expected.

Toy_Model has then been updated to load the "Default" config file, convert into the Config objects then all references to the previous constants have been updated to refer to the Config Objects. I have tested that the model still launches successfully after these changes.